### PR TITLE
add reverting execTransaction function

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -4,6 +4,7 @@ module.exports = {
     "test/TestAvatar.sol",
     "test/TestContract.sol",
     "test/TestFactory.sol",
+    "test/MultiSend.sol"
   ],
   mocha: {
     grep: "@skip-on-coverage", // Find everything with this tag

--- a/contracts/Roles.sol
+++ b/contracts/Roles.sol
@@ -85,6 +85,7 @@ contract Roles is Modifier {
         address target,
         bytes4 functionSig,
         uint16 parameterIndex,
+        bytes value,
         bool allowed
     );
     event SetParameterCompValue(
@@ -357,6 +358,7 @@ contract Roles is Modifier {
             targetAddress,
             functionSig,
             paramIndex,
+            value,
             roles[role]
                 .targetAddresses[targetAddress]
                 .functions[functionSig]
@@ -597,6 +599,8 @@ contract Roles is Modifier {
             } else {
                 return false;
             }
+        } else {
+            return false;
         }
     }
 

--- a/contracts/Roles.sol
+++ b/contracts/Roles.sol
@@ -46,7 +46,7 @@ contract Roles is Modifier {
     event SetMulitSendAddress(address multiSendAddress, bool allowed);
     event SetParametersScoped(
         uint16 role,
-        address target,
+        address targetAddress,
         bytes4 functionSig,
         bool scoped,
         bool[] paramsScoped,
@@ -82,7 +82,7 @@ contract Roles is Modifier {
     );
     event SetParameterAllowedValue(
         uint16 role,
-        address target,
+        address targetAddress,
         bytes4 functionSig,
         uint16 parameterIndex,
         bytes value,
@@ -90,7 +90,7 @@ contract Roles is Modifier {
     );
     event SetParameterCompValue(
         uint16 role,
-        address target,
+        address targetAddress,
         bytes4 functionSig,
         uint16 parameterIndex,
         bytes compValue
@@ -273,7 +273,7 @@ contract Roles is Modifier {
             .compTypes = compTypes;
         emit SetParametersScoped(
             role,
-            target,
+            targetAddress,
             functionSig,
             roles[role]
                 .targetAddresses[targetAddress]
@@ -389,7 +389,7 @@ contract Roles is Modifier {
 
         emit SetParameterCompValue(
             role,
-            target,
+            targetAddress,
             functionSig,
             paramIndex,
             roles[role]
@@ -457,6 +457,25 @@ contract Roles is Modifier {
                 .functions[functionSig]
                 .compTypes
         );
+    }
+
+    /// @dev Returns the comparison value for a parameter.
+    /// @param role The role to check.
+    /// @param targetAddress Target address to check.
+    /// @param functionSig Function signature for the function to check.
+    /// @param paramIndex Index of the parameter to check.
+    function getCompValue(
+        uint16 role,
+        address targetAddress,
+        bytes4 functionSig,
+        uint16 paramIndex
+    ) public view returns (bytes memory) {
+        return
+            roles[role]
+                .targetAddresses[targetAddress]
+                .functions[functionSig]
+                .values[paramIndex]
+                .compValue;
     }
 
     function isRoleMember(address module, uint16 role)

--- a/contracts/Roles.sol
+++ b/contracts/Roles.sol
@@ -354,7 +354,7 @@ contract Roles is Modifier {
 
         emit SetParameterAllowedValue(
             role,
-            target,
+            targetAddress,
             functionSig,
             paramIndex,
             roles[role]

--- a/contracts/Roles.sol
+++ b/contracts/Roles.sol
@@ -131,7 +131,7 @@ contract Roles is Modifier {
     error ParameterGreaterThanAllowed();
 
     /// Arrays must be the same length
-    error ArraysDiffferentLength();
+    error ArraysDifferentLength();
 
     /// @param _owner Address of the owner
     /// @param _avatar Address of the avatar (e.g. a Gnosis Safe)
@@ -401,13 +401,17 @@ contract Roles is Modifier {
         );
     }
 
+    /// @dev Assigns and revokes roles to a given module.
+    /// @param module Module on which to assign/revoke roles.
+    /// @param _roles Roles to assign/revoke.
+    /// @param memberOf Assign (true) or revoke (false) corresponding _roles.
     function assignRoles(
         address module,
         uint16[] calldata _roles,
         bool[] memory memberOf
     ) external onlyOwner {
         if (_roles.length != memberOf.length) {
-            revert ArraysDiffferentLength();
+            revert ArraysDifferentLength();
         }
         for (uint16 i = 0; i < _roles.length; i++) {
             roles[_roles[i]].members[module] = memberOf[i];
@@ -494,7 +498,11 @@ contract Roles is Modifier {
                 .compValue;
     }
 
-    function isRoleMember(address module, uint16 role)
+    /// @dev Returns bool to indicate whether (true) or not (false) a given module is a member of a role.
+    /// @param role Role to check.
+    /// @param module Module to check.
+    /// @return bool indicating whether module is a member or role.
+    function isRoleMember(uint16 role, address module)
         external
         view
         returns (bool)

--- a/contracts/Roles.sol
+++ b/contracts/Roles.sol
@@ -11,7 +11,6 @@ contract Roles is Modifier {
     }
 
     struct Parameter {
-        //Comparison compType;
         mapping(bytes => bool) allowed;
         bytes compValue;
     }
@@ -465,7 +464,6 @@ contract Roles is Modifier {
         uint256 dataLength;
         // transaction data begins at byte 100, increment i by the transaction data length
         // + 85 bytes of the to, value, and operation bytes until we reach the end of the data
-        uint256 length;
         for (uint256 i = 100; i < transactions.length; i += (85 + dataLength)) {
             assembly {
                 // First byte of the data is the operation.

--- a/contracts/Roles.sol
+++ b/contracts/Roles.sol
@@ -101,6 +101,7 @@ contract Roles is Modifier {
         address indexed avatar,
         address target
     );
+    event SetDefaultRole(address module, uint16 defaultRole);
 
     /// `setUpModules` has already been called
     error SetUpModulesAlreadyCalled();
@@ -417,14 +418,29 @@ contract Roles is Modifier {
         emit AssignRoles(module, _roles);
     }
 
+    /// @dev Sets the default role used for a module if it calls execTransactionFromModule() or execTransactionFromModuleReturnData().
+    /// @param module Address of the module on which to set default role.
+    /// @param role Role to be set as default.
     function setDefaultRole(address module, uint16 role) external onlyOwner {
         defaultRoles[module] = role;
+        emit SetDefaultRole(module, defaultRoles[module]);
     }
 
+    /// @dev Returns the default role for a given module.
+    /// @param module Module to be checked.
+    /// @return Default role of given module.
     function getDefaultRole(address module) external view returns (uint16) {
         return defaultRoles[module];
     }
 
+    /// @dev Returns details on whether and how functions parameters are scoped.
+    /// @param role Role to check.
+    /// @param targetAddress Target address to check.
+    /// @param functionSig Function signature of the function to check.
+    /// @return bool describing whether (true) or not (false) the function is scoped.
+    /// @return bool[] describing parameter types are variable(true) or fixed (false) length.
+    /// @return bool[] describing whether (true) or not (false) the parameters are scoped.
+    /// @return Comparison[] describing the comparison type for each parameter: EqualTo, GreaterThan, or LessThan.
     function getParameterScopes(
         uint16 role,
         address targetAddress,

--- a/contracts/Roles.sol
+++ b/contracts/Roles.sol
@@ -592,7 +592,7 @@ contract Roles is Modifier {
                     }
                     checkParameter(targetAddress, role, data, i, out);
 
-                    // the parameter is not an array and has no length encoding
+                // the parameter is not an array and has no length encoding
                 } else {
                     // fixed value data is positioned within the parameter block
                     pos += 32;

--- a/contracts/Roles.sol
+++ b/contracts/Roles.sol
@@ -237,7 +237,7 @@ contract Roles is Modifier {
         );
     }
 
-    /// @dev Sets whether or not calls to an address should be scoped to specific function signatures.
+    /// @dev Sets whether or not calls should be scoped to specific parameter value or range of values.
     /// @notice Only callable by owner.
     /// @param role Role to set for.
     /// @param targetAddress Address to be scoped/unscoped.
@@ -330,7 +330,7 @@ contract Roles is Modifier {
         );
     }
 
-    /// @dev Sets whether or not calls to an address should be scoped to specific function signatures.
+    /// @dev Sets whether or not a specific parameter value is allowed for a function call.
     /// @notice Only callable by owner.
     /// @param role Role to set for
     /// @param targetAddress Address to be scoped/unscoped.

--- a/contracts/Roles.sol
+++ b/contracts/Roles.sol
@@ -870,8 +870,7 @@ contract Roles is Modifier {
         bytes calldata data,
         Enum.Operation operation
     ) public override moduleOnly returns (bool success) {
-        uint16 role = defaultRoles[msg.sender];
-        execTransactionWithRole(to, value, data, operation, role);
+        execTransactionWithRole(to, value, data, operation, defaultRoles[msg.sender]);
     }
 
     /// @dev Passes a transaction to the modifier, expects return data.
@@ -891,8 +890,7 @@ contract Roles is Modifier {
         moduleOnly
         returns (bool success, bytes memory returnData)
     {
-        uint16 role = defaultRoles[msg.sender];
-        return execTransactionWithRoleReturnData(to, value, data, operation, role);
+        return execTransactionWithRoleReturnData(to, value, data, operation, defaultRoles[msg.sender]);
     }
 
     /// @dev Passes a transaction to the modifier assuming the specified role. Reverts if the passed transaction fails.

--- a/test/Roles.spec.ts
+++ b/test/Roles.spec.ts
@@ -1746,19 +1746,41 @@ describe("RolesModifier", async () => {
 
     it("sets allowed function to true", async () => {
       const { avatar, modifier} = await txSetup();
-      const tx = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 1, "0xabcd", true);
+      const tx = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 0, "0xabcd", true);
       expect(avatar.exec(modifier.address, 0, tx.data));
-      expect(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 1, "0xabcd")).to.be.equals(true);
+      const paramScoped =
+        await modifier.populateTransaction.setParametersScoped(
+          1,
+          AddressOne,
+          "0x12345678",
+          true,
+          [true],
+          [false],
+          [0]
+        );
+      await avatar.exec(modifier.address, 0, paramScoped.data)
+      expect(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 0, "0xabcd")).to.be.equals(true);
     });
 
     it("sets allowed function to false", async () => {
       const { avatar, modifier } = await txSetup();
-      const txTrue = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 1, "0xabcd", "0xabcd");
+      const txTrue = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 0, "0xabcd", "0xabcd");
       expect(avatar.exec(modifier.address, 0, txTrue.data));
-      expect(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 1, "0xabcd")).to.be.equals(true);
-      const txFalse = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 1, "0xabcd", "0xabcd");
+      const paramScoped =
+        await modifier.populateTransaction.setParametersScoped(
+          1,
+          AddressOne,
+          "0x12345678",
+          true,
+          [true],
+          [false],
+          [0]
+        );
+      await avatar.exec(modifier.address, 0, paramScoped.data)
+      expect(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 0, "0xabcd")).to.be.equals(true);
+      const txFalse = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 0, "0xabcdef", "0xabcdef");
       expect(avatar.exec(modifier.address, 0, txFalse.data));
-      expect(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 1, "0xabcd")).to.be.equals(false);
+      expect(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 0, "0xabcd")).to.be.equals(false);
     });
 
     it("emits event with correct params", async () => {

--- a/test/Roles.spec.ts
+++ b/test/Roles.spec.ts
@@ -1744,46 +1744,49 @@ describe("RolesModifier", async () => {
       expect(modifier.setParameterAllowedValue(1, AddressOne, "0x12345678", 1, "0xabcd", true)).to.be.revertedWith('Ownable: caller is not the owner');
     });
 
-    it("sets allowed parameter value to true", async () => {
+    it.only("sets allowed parameter value to true", async () => {
       const { avatar, modifier} = await txSetup();
       const tx = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 0, "0xabcd", true);
-      expect(avatar.exec(modifier.address, 0, tx.data));
       const paramScoped =
-        await modifier.populateTransaction.setParametersScoped(
-          1,
-          AddressOne,
-          "0x12345678",
-          true,
-          [true],
-          [false],
-          [0]
+      await modifier.populateTransaction.setParametersScoped(
+        1,
+        AddressOne,
+        "0x12345678",
+        true,
+        [true],
+        [false],
+        [0]
         );
       await avatar.exec(modifier.address, 0, paramScoped.data)
+      expect(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 0, "0xabcd")).to.be.equals(false);
+      expect(avatar.exec(modifier.address, 0, tx.data));
       expect(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 0, "0xabcd")).to.be.equals(true);
     });
 
     it.only("sets allowed parameter value to false", async () => {
       const { avatar, modifier } = await txSetup();
       const txTrue = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 0, "0xabcd", true);
-      expect(avatar.exec(modifier.address, 0, txTrue.data));
+      const txFalse = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 0, "0xabcd", false);
       const paramScoped =
-        await modifier.populateTransaction.setParametersScoped(
-          1,
-          AddressOne,
-          "0x12345678",
-          true,
-          [true],
-          [false],
-          [0]
+      await modifier.populateTransaction.setParametersScoped(
+        1,
+        AddressOne,
+        "0x12345678",
+        true,
+        [true],
+        [false],
+        [0]
         );
       await avatar.exec(modifier.address, 0, paramScoped.data)
+      console.log(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 0, "0xabcd"));
+      expect(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 0, "0xabcd")).to.be.equals(false);
+      expect(avatar.exec(modifier.address, 0, txTrue.data));
       expect(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 0, "0xabcd")).to.be.equals(true);
-      const txFalse = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 0, "0xabcdef", false);
-      expect(avatar.exec(modifier.address, 0, txFalse.data));
+      await expect(avatar.exec(modifier.address, 0, txFalse.data)).to.emit(modifier, "SetParameterAllowedValue").withArgs(1, AddressOne, "0x12345678", 0, "0xabcd", false);
       expect(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 0, "0xabcd")).to.be.equals(false);
     });
 
-    it.only("emits event with correct params", async () => {
+    it("emits event with correct params", async () => {
       const { avatar, modifier } = await txSetup();
       const tx = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 1, "0xabcd", true);
       await expect(await avatar.exec(modifier.address, 0, tx.data))

--- a/test/Roles.spec.ts
+++ b/test/Roles.spec.ts
@@ -2035,4 +2035,31 @@ describe("RolesModifier", async () => {
       await expect(await modifier.isAllowedToDelegateCall(1, AddressOne)).to.be.equals(true);
     });
   });
+
+
+  describe("isAllowedValueForParam()", () => {
+    it("returns false if not set", async () => {
+      const { avatar, modifier} = await txSetup();
+      await expect(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 0, "0x1234")).to.be.equals(false);
+    });
+    
+    it("returns true if set", async () => {
+      const { avatar, modifier} = await txSetup();
+      const paramScoped =
+      await modifier.populateTransaction.setParametersScoped(
+        1,
+        AddressOne,
+        "0x12345678",
+        true,
+        [true],
+        [true],
+        [0]
+        );
+      await avatar.exec(modifier.address, 0, paramScoped.data)
+      await expect(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 0, "0xabcd")).to.be.equals(false);
+      const tx = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 0, "0xabcd", true);
+      await expect(await avatar.exec(modifier.address, 0, tx.data));
+      await expect(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 0, "0xabcd")).to.be.equals(true);
+    });
+  });
 });

--- a/test/Roles.spec.ts
+++ b/test/Roles.spec.ts
@@ -426,6 +426,12 @@ describe("RolesModifier", async () => {
         );
       await avatar.exec(modifier.address, 0, allowTargetAddress.data);
 
+      const defaultRole = await modifier.populateTransaction.setDefaultRole(
+        user1.address,
+        1
+      );
+      await avatar.exec(modifier.address, 0, defaultRole.data);
+
       const mint = await testContract.populateTransaction.mint(
         user1.address,
         99
@@ -434,7 +440,7 @@ describe("RolesModifier", async () => {
       const someOtherAddress = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
       await expect(
         modifier.execTransactionFromModule(someOtherAddress, 0, mint.data, 0)
-      ).to.be.revertedWith("NotAllowed");
+      ).to.be.revertedWith("TargetAddressNotAllowed()");
     });
 
     it("executes a call to an allowed target", async () => {
@@ -544,7 +550,7 @@ describe("RolesModifier", async () => {
           mint.data,
           0
         )
-      ).to.be.revertedWith("ParameterNotAllowed");
+      ).to.be.revertedWith("ParameterNotAllowed()");
     });
 
     it("executes a call with allowed value parameter", async () => {
@@ -1455,6 +1461,12 @@ describe("RolesModifier", async () => {
           true
         );
       await avatar.exec(modifier.address, 0, allowTargetAddress.data);
+
+      const defaultRole = await modifier.populateTransaction.setDefaultRole(
+        user1.address,
+        1
+      );
+      await avatar.exec(modifier.address, 0, defaultRole.data);
 
       const mint = await testContract.populateTransaction.mint(
         user1.address,

--- a/test/Roles.spec.ts
+++ b/test/Roles.spec.ts
@@ -1849,4 +1849,98 @@ describe("RolesModifier", async () => {
       .withArgs(1, AddressOne, "0x12345678", 1, "0xabcd");
     });
   });
+
+  describe("setDefaultRole()", () => {
+    it("reverts if not authorized", async () => {
+      const { avatar, modifier } = await txSetup();
+      expect(modifier.setDefaultRole(AddressOne, 1)).to.be.revertedWith('Ownable: caller is not the owner');
+    });
+
+    it("sets default role", async () => {
+      const { avatar, modifier} = await txSetup();
+      const tx = await modifier.populateTransaction.setDefaultRole(AddressOne, 1);
+      await expect(await modifier.getDefaultRole(AddressOne)).to.be.equals(0);
+      expect(await avatar.exec(modifier.address, 0, tx.data));
+      await expect(await modifier.getDefaultRole(AddressOne)).to.be.equals(1);
+    });
+
+    
+    it("emits event with correct params", async () => {
+      const { avatar, modifier} = await txSetup();
+      const tx = await modifier.populateTransaction.setDefaultRole(AddressOne, 1);
+      await expect(await modifier.getDefaultRole(AddressOne)).to.be.equals(0);
+      await expect(await avatar.exec(modifier.address, 0, tx.data)).to.emit(modifier, "SetDefaultRole").withArgs(AddressOne, 1);
+      await expect(await modifier.getDefaultRole(AddressOne)).to.be.equals(1);
+    });
+  });
+
+  describe("getDefaultRole()", () => {
+    it("returns 0 if not set", async () => {
+      const { avatar, modifier} = await txSetup();
+      await expect(await modifier.getDefaultRole(AddressOne)).to.be.equals(0);
+    });
+
+    
+    it("returns role if set", async () => {
+      const { avatar, modifier} = await txSetup();
+      const tx = await modifier.populateTransaction.setDefaultRole(AddressOne, 1);
+      await expect(await modifier.getDefaultRole(AddressOne)).to.be.equals(0);
+      await expect(await avatar.exec(modifier.address, 0, tx.data));
+      await expect(await modifier.getDefaultRole(AddressOne)).to.be.equals(1);
+    });
+  });
+
+  describe("getParameterScopes()", () => {
+    it("returns 0 if not set", async () => {
+      const { avatar, modifier} = await txSetup();
+      const result = (await modifier.getParameterScopes(1, AddressOne, "0x12345678")).toString();
+      await expect(result).to.be.equals("false,,,");
+    });
+
+    
+    it("returns role if set", async () => {
+      const { avatar, modifier} = await txSetup();
+      const tx = await modifier.populateTransaction.setParametersScoped(1,AddressOne, "0x12345678", true, [true],[true],[1]);
+      const resultFalse = (await modifier.getParameterScopes(1, AddressOne, "0x12345678")).toString();
+      await expect(resultFalse).to.be.equals("false,,,");
+      await expect(await avatar.exec(modifier.address, 0, tx.data));
+      const resultTrue = (await modifier.getParameterScopes(1, AddressOne, "0x12345678")).toString();
+      await expect(resultTrue).to.be.equals("true,true,true,1");
+    });
+  });
+
+  describe("getDefaultRole()", () => {
+    it("returns 0 if not set", async () => {
+      const { avatar, modifier} = await txSetup();
+      await expect(await modifier.getDefaultRole(AddressOne)).to.be.equals(0);
+    });
+
+    
+    it("returns role if set", async () => {
+      const { avatar, modifier} = await txSetup();
+      const tx = await modifier.populateTransaction.setDefaultRole(AddressOne, 1);
+      await expect(await modifier.getDefaultRole(AddressOne)).to.be.equals(0);
+      await expect(await avatar.exec(modifier.address, 0, tx.data));
+      await expect(await modifier.getDefaultRole(AddressOne)).to.be.equals(1);
+    });
+  });
+
+  describe("getCompValue()", () => {
+    it.only("returns 0 if not set", async () => {
+      const { avatar, modifier} = await txSetup();
+      const result = (await modifier.getCompValue(1, AddressOne, "0x12345678", 0)).toString();
+      await expect(result).to.be.equals("0x");
+    });
+
+    
+    it.only("returns role if set", async () => {
+      const { avatar, modifier} = await txSetup();
+      const tx = await modifier.populateTransaction.setParameterCompValue(1,AddressOne, "0x12345678", 0, "0x1234");
+      const resultFalse = (await modifier.getCompValue(1, AddressOne, "0x12345678", 0)).toString();
+      await expect(resultFalse).to.be.equals("0x");
+      await expect(await avatar.exec(modifier.address, 0, tx.data));
+      const resultTrue = (await modifier.getCompValue(1, AddressOne, "0x12345678", 0)).toString();
+      await expect(resultTrue).to.be.equals("0x1234");
+    });
+  });
 });

--- a/test/Roles.spec.ts
+++ b/test/Roles.spec.ts
@@ -1967,7 +1967,7 @@ describe("RolesModifier", async () => {
       await expect(await modifier.isAllowedTargetAddress(1, AddressOne)).to.be.equals(false);
     });
     
-    it("returns role if set", async () => {
+    it("returns true if set", async () => {
       const { avatar, modifier} = await txSetup();
       await expect(await modifier.isAllowedTargetAddress(1, AddressOne)).to.be.equals(false);
       const tx = await modifier.populateTransaction.setTargetAddressAllowed(1, AddressOne, true);
@@ -1982,7 +1982,7 @@ describe("RolesModifier", async () => {
       await expect(await modifier.isScoped(1, AddressOne)).to.be.equals(false);
     });
     
-    it("returns role if set", async () => {
+    it("returns true if set", async () => {
       const { avatar, modifier} = await txSetup();
       await expect(await modifier.isScoped(1, AddressOne)).to.be.equals(false);
       const tx = await modifier.populateTransaction.setTargetAddressScoped(1, AddressOne, true);
@@ -1997,7 +1997,7 @@ describe("RolesModifier", async () => {
       await expect(await modifier.isSendAllowed(1, AddressOne)).to.be.equals(false);
     });
     
-    it("returns role if set", async () => {
+    it("returns true if set", async () => {
       const { avatar, modifier} = await txSetup();
       await expect(await modifier.isSendAllowed(1, AddressOne)).to.be.equals(false);
       const tx = await modifier.populateTransaction.setSendAllowedOnTargetAddress(1, AddressOne, true);
@@ -2012,12 +2012,27 @@ describe("RolesModifier", async () => {
       await expect(await modifier.isAllowedFunction(1, AddressOne, "0x12345678")).to.be.equals(false);
     });
     
-    it("returns role if set", async () => {
+    it("returns true if set", async () => {
       const { avatar, modifier} = await txSetup();
       await expect(await modifier.isAllowedFunction(1, AddressOne, "0x12345678")).to.be.equals(false);
       const tx = await modifier.populateTransaction.setAllowedFunction(1, AddressOne, "0x12345678", true);
       await expect(await avatar.exec(modifier.address, 0, tx.data));
       await expect(await modifier.isAllowedFunction(1, AddressOne, "0x12345678")).to.be.equals(true);
+    });
+  });
+
+  describe("isAllowedToDelegateCall()", () => {
+    it("returns false if not set", async () => {
+      const { avatar, modifier} = await txSetup();
+      await expect(await modifier.isAllowedToDelegateCall(1, AddressOne)).to.be.equals(false);
+    });
+    
+    it("returns true if set", async () => {
+      const { avatar, modifier} = await txSetup();
+      await expect(await modifier.isAllowedToDelegateCall(1, AddressOne)).to.be.equals(false);
+      const tx = await modifier.populateTransaction.setDelegateCallAllowedOnTargetAddress(1, AddressOne, true);
+      await expect(await avatar.exec(modifier.address, 0, tx.data));
+      await expect(await modifier.isAllowedToDelegateCall(1, AddressOne)).to.be.equals(true);
     });
   });
 });

--- a/test/Roles.spec.ts
+++ b/test/Roles.spec.ts
@@ -1552,7 +1552,9 @@ describe("RolesModifier", async () => {
     it("sets allowed address to true", async () => {
       const { avatar, modifier} = await txSetup();
       const tx = await modifier.populateTransaction.setTargetAddressAllowed(1, AddressOne, true);
-      expect(avatar.exec(modifier.address, 0, tx.data));
+      expect(avatar.exec(modifier.address, 0, tx.data))
+      .to.emit(modifier, "SetTargetAddressAllowed")
+      .withArgs(1, AddressOne, true);
       expect(await modifier.isAllowedTargetAddress(1, AddressOne)).to.be.equals(true);
     });
 

--- a/test/Roles.spec.ts
+++ b/test/Roles.spec.ts
@@ -2040,6 +2040,17 @@ describe("RolesModifier", async () => {
   describe("isAllowedValueForParam()", () => {
     it("returns false if not set", async () => {
       const { avatar, modifier} = await txSetup();
+      const paramScoped =
+      await modifier.populateTransaction.setParametersScoped(
+        1,
+        AddressOne,
+        "0x12345678",
+        true,
+        [true],
+        [true],
+        [0]
+        );
+      await avatar.exec(modifier.address, 0, paramScoped.data);
       await expect(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 0, "0x1234")).to.be.equals(false);
     });
     

--- a/test/Roles.spec.ts
+++ b/test/Roles.spec.ts
@@ -2005,4 +2005,19 @@ describe("RolesModifier", async () => {
       await expect(await modifier.isSendAllowed(1, AddressOne)).to.be.equals(true);
     });
   });
+
+  describe("isAllowedFunction()", () => {
+    it("returns false if not set", async () => {
+      const { avatar, modifier} = await txSetup();
+      await expect(await modifier.isAllowedFunction(1, AddressOne, "0x12345678")).to.be.equals(false);
+    });
+    
+    it("returns role if set", async () => {
+      const { avatar, modifier} = await txSetup();
+      await expect(await modifier.isAllowedFunction(1, AddressOne, "0x12345678")).to.be.equals(false);
+      const tx = await modifier.populateTransaction.setAllowedFunction(1, AddressOne, "0x12345678", true);
+      await expect(await avatar.exec(modifier.address, 0, tx.data));
+      await expect(await modifier.isAllowedFunction(1, AddressOne, "0x12345678")).to.be.equals(true);
+    });
+  });
 });

--- a/test/Roles.spec.ts
+++ b/test/Roles.spec.ts
@@ -1119,12 +1119,11 @@ describe("RolesModifier", async () => {
         [99]
       );
       const paramAllowed_lessThan =
-        await modifier.populateTransaction.setParameterAllowedValue(
+        await modifier.populateTransaction.setParameterCompValue(
           1,
           testContract.address,
           "0x40c10f19",
           1,
-          encodedParam_2,
           encodedParam_2
         );
 
@@ -1374,12 +1373,11 @@ describe("RolesModifier", async () => {
         [99]
       );
       const paramAllowed_lessThan =
-        await modifier.populateTransaction.setParameterAllowedValue(
+        await modifier.populateTransaction.setParameterCompValue(
           1,
           testContract.address,
           "0x40c10f19",
           1,
-          encodedParam_2,
           encodedParam_2
         );
 
@@ -1736,6 +1734,38 @@ describe("RolesModifier", async () => {
       const tx = await modifier.populateTransaction.setAllowedFunction(1, AddressOne, "0x12345678", true);
       expect(await avatar.exec(modifier.address, 0, tx.data))
       .to.emit(modifier, "SetFunctionAllowedOnTargetAddress")
+      .withArgs(1, AddressOne, "0x12345678", true);
+    });
+  });
+
+  describe("setParameterAllowedValue()", () => {
+    it("reverts if not authorized", async () => {
+      const { avatar, modifier } = await txSetup();
+      expect(modifier.setParameterAllowedValue(1, AddressOne, "0x12345678", 1, "0xabcd", true)).to.be.revertedWith('Ownable: caller is not the owner');
+    });
+
+    it("sets allowed function to true", async () => {
+      const { avatar, modifier} = await txSetup();
+      const tx = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 1, "0xabcd", true);
+      expect(avatar.exec(modifier.address, 0, tx.data));
+      expect(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 1, "0xabcd")).to.be.equals(true);
+    });
+
+    it("sets allowed function to false", async () => {
+      const { avatar, modifier } = await txSetup();
+      const txTrue = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 1, "0xabcd", "0xabcd");
+      expect(avatar.exec(modifier.address, 0, txTrue.data));
+      expect(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 1, "0xabcd")).to.be.equals(true);
+      const txFalse = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 1, "0xabcd", "0xabcd");
+      expect(avatar.exec(modifier.address, 0, txFalse.data));
+      expect(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 1, "0xabcd")).to.be.equals(false);
+    });
+
+    it("emits event with correct params", async () => {
+      const { avatar, modifier } = await txSetup();
+      const tx = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 1, "0xabcd", "0xabcd");
+      expect(await avatar.exec(modifier.address, 0, tx.data))
+      .to.emit(modifier, "SetParameterAllowedValues")
       .withArgs(1, AddressOne, "0x12345678", true);
     });
   });

--- a/test/Roles.spec.ts
+++ b/test/Roles.spec.ts
@@ -1744,7 +1744,7 @@ describe("RolesModifier", async () => {
       expect(modifier.setParameterAllowedValue(1, AddressOne, "0x12345678", 1, "0xabcd", true)).to.be.revertedWith('Ownable: caller is not the owner');
     });
 
-    it.only("sets allowed parameter value to true", async () => {
+    it("sets allowed parameter value to true", async () => {
       const { avatar, modifier} = await txSetup();
       const tx = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 0, "0xabcd", true);
       const paramScoped =
@@ -1763,7 +1763,7 @@ describe("RolesModifier", async () => {
       expect(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 0, "0xabcd")).to.be.equals(true);
     });
 
-    it.only("sets allowed parameter value to false", async () => {
+    it("sets allowed parameter value to false", async () => {
       const { avatar, modifier } = await txSetup();
       const txTrue = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 0, "0xabcd", true);
       const txFalse = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 0, "0xabcd", false);
@@ -1778,7 +1778,6 @@ describe("RolesModifier", async () => {
         [0]
         );
       await avatar.exec(modifier.address, 0, paramScoped.data)
-      console.log(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 0, "0xabcd"));
       expect(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 0, "0xabcd")).to.be.equals(false);
       expect(avatar.exec(modifier.address, 0, txTrue.data));
       expect(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 0, "0xabcd")).to.be.equals(true);
@@ -1791,7 +1790,63 @@ describe("RolesModifier", async () => {
       const tx = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 1, "0xabcd", true);
       await expect(await avatar.exec(modifier.address, 0, tx.data))
       .to.emit(modifier, "SetParameterAllowedValue")
-      .withArgs(1, AddressOne, "0x12345678", 1, true);
+      .withArgs(1, AddressOne, "0x12345678", 1, "0xabcd", true);
+    });
+  });
+
+  describe("setParameterCompValue()", () => {
+    it("reverts if not authorized", async () => {
+      const { avatar, modifier } = await txSetup();
+      expect(modifier.setParameterCompValue(1, AddressOne, "0x12345678", 1, "0xabcd")).to.be.revertedWith('Ownable: caller is not the owner');
+    });
+
+    it("sets compValue value to non-zero", async () => {
+      const { avatar, modifier} = await txSetup();
+      const tx = await modifier.populateTransaction.setParameterCompValue(1, AddressOne, "0x12345678", 0, "0xabcd");
+      const paramScoped =
+      await modifier.populateTransaction.setParametersScoped(
+        1,
+        AddressOne,
+        "0x12345678",
+        true,
+        [true],
+        [false],
+        [0]
+        );
+      await avatar.exec(modifier.address, 0, paramScoped.data)
+      expect(await modifier.getCompValue(1, AddressOne, "0x12345678", 0)).to.be.equals("0x");
+      expect(avatar.exec(modifier.address, 0, tx.data));
+      expect(await modifier.getCompValue(1, AddressOne, "0x12345678", 0)).to.be.equals("0xabcd");
+    });
+
+    it("sets compValue to zero", async () => {
+      const { avatar, modifier } = await txSetup();
+      const txTrue = await modifier.populateTransaction.setParameterCompValue(1, AddressOne, "0x12345678", 0, "0xabcd");
+      const txFalse = await modifier.populateTransaction.setParameterCompValue(1, AddressOne, "0x12345678", 0, "0x");
+      const paramScoped =
+      await modifier.populateTransaction.setParametersScoped(
+        1,
+        AddressOne,
+        "0x12345678",
+        true,
+        [true],
+        [false],
+        [0]
+        );
+      await avatar.exec(modifier.address, 0, paramScoped.data)
+      expect(await modifier.getCompValue(1, AddressOne, "0x12345678", 0)).to.be.equals("0x");
+      expect(avatar.exec(modifier.address, 0, txTrue.data));
+      expect(await modifier.getCompValue(1, AddressOne, "0x12345678", 0)).to.be.equals("0xabcd");
+      await expect(avatar.exec(modifier.address, 0, txFalse.data)).to.emit(modifier, "SetParameterCompValue").withArgs(1, AddressOne, "0x12345678", 0, "0x");
+      expect(await modifier.getCompValue(1, AddressOne, "0x12345678", 0)).to.be.equals("0x");
+    });
+
+    it("emits event with correct params", async () => {
+      const { avatar, modifier } = await txSetup();
+      const tx = await modifier.populateTransaction.setParameterCompValue(1, AddressOne, "0x12345678", 1, "0xabcd");
+      await expect(await avatar.exec(modifier.address, 0, tx.data))
+      .to.emit(modifier, "SetParameterCompValue")
+      .withArgs(1, AddressOne, "0x12345678", 1, "0xabcd");
     });
   });
 });

--- a/test/Roles.spec.ts
+++ b/test/Roles.spec.ts
@@ -28,6 +28,165 @@ describe("RolesModifier", async () => {
     return { ...base, Modifier, modifier };
   });
 
+  const txSetup = deployments.createFixture(async () => {
+    const baseAvatar = await setupTestWithTestAvatar();
+    const encodedParam_1 = ethers.utils.defaultAbiCoder.encode(
+      ["address"],
+      [user1.address]
+    );
+    const paramAllowed_1 =
+      await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
+        1,
+        baseAvatar.testContract.address,
+        "0x40c10f19",
+        0,
+        encodedParam_1,
+        "0x"
+      );
+    const encodedParam_2 = ethers.utils.defaultAbiCoder.encode(
+      ["uint256"],
+      [99]
+    );
+    const paramAllowed_2 =
+      await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
+        1,
+        baseAvatar.testContract.address,
+        "0x40c10f19",
+        1,
+        encodedParam_2,
+        "0x"
+      );
+    const encodedParam_3 = ethers.utils.solidityPack(
+      ["string"],
+      ["This is a dynamic array"]
+    );
+    const encodedParam_4 = ethers.utils.defaultAbiCoder.encode(
+      ["uint256"],
+      [4]
+    );
+    const encodedParam_5 = ethers.utils.solidityPack(["string"], ["Test"]);
+    const encodedParam_6 = ethers.utils.defaultAbiCoder.encode(
+      ["bool"],
+      [true]
+    );
+    const encodedParam_7 = ethers.utils.defaultAbiCoder.encode(["uint8"], [3]);
+    const encodedParam_8 = ethers.utils.solidityPack(["string"], ["weeeeeeee"]);
+    const encodedParam_9 = ethers.utils.solidityPack(
+      ["string"],
+      [
+        "This is an input that is larger than 32 bytes and must be scanned for correctness",
+      ]
+    );
+    const paramAllowed_3 =
+      await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
+        1,
+        baseAvatar.testContract.address,
+        "0x273454bf",
+        0,
+        encodedParam_3,
+        "0x"
+      );
+    const paramAllowed_4 =
+      await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
+        1,
+        baseAvatar.testContract.address,
+        "0x273454bf",
+        1,
+        encodedParam_4,
+        "0x"
+      );
+    const paramAllowed_5 =
+      await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
+        1,
+        baseAvatar.testContract.address,
+        "0x273454bf",
+        2,
+        encodedParam_5,
+        "0x"
+      );
+    const paramAllowed_6 =
+      await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
+        1,
+        baseAvatar.testContract.address,
+        "0x273454bf",
+        3,
+        encodedParam_6,
+        "0x"
+      );
+    const paramAllowed_7 =
+      await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
+        1,
+        baseAvatar.testContract.address,
+        "0x273454bf",
+        4,
+        encodedParam_7,
+        "0x"
+      );
+    const paramAllowed_8 =
+      await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
+        1,
+        baseAvatar.testContract.address,
+        "0x273454bf",
+        5,
+        encodedParam_8,
+        "0x"
+      );
+    const paramAllowed_9 =
+      await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
+        1,
+        baseAvatar.testContract.address,
+        "0x273454bf",
+        6,
+        encodedParam_9,
+        "0x"
+      );
+    const mint = await baseAvatar.testContract.populateTransaction.mint(
+      user1.address,
+      99
+    );
+    const tx_1 = buildContractCall(
+      baseAvatar.testContract,
+      "mint",
+      [user1.address, 99],
+      0
+    );
+    const tx_2 = buildContractCall(
+      baseAvatar.testContract,
+      "mint",
+      [user1.address, 99],
+      0
+    );
+    const tx_3 = await buildContractCall(
+      baseAvatar.testContract,
+      "testDynamic",
+      [
+        "This is a dynamic array",
+        4,
+        "Test",
+        true,
+        3,
+        "weeeeeeee",
+        "This is an input that is larger than 32 bytes and must be scanned for correctness",
+      ],
+      0
+    );
+    return {
+      ...baseAvatar,
+      paramAllowed_1,
+      paramAllowed_2,
+      paramAllowed_3,
+      paramAllowed_4,
+      paramAllowed_5,
+      paramAllowed_6,
+      paramAllowed_7,
+      paramAllowed_8,
+      paramAllowed_9,
+      tx_1,
+      tx_2,
+      tx_3,
+    };
+  });
+
   const [user1, user2] = waffle.provider.getWallets();
 
   describe("setUp()", async () => {
@@ -47,14 +206,14 @@ describe("RolesModifier", async () => {
 
   describe("disableModule()", async () => {
     it("reverts if not authorized", async () => {
-      const { modifier } = await setupTestWithTestAvatar();
+      const { modifier } = await txSetup();
       await expect(
         modifier.disableModule(FirstAddress, user1.address)
       ).to.be.revertedWith("Ownable: caller is not the owner");
     });
 
     it("reverts if module is null or sentinel", async () => {
-      const { avatar, modifier } = await setupTestWithTestAvatar();
+      const { avatar, modifier } = await txSetup();
       const disable = await modifier.populateTransaction.disableModule(
         FirstAddress,
         FirstAddress
@@ -65,7 +224,7 @@ describe("RolesModifier", async () => {
     });
 
     it("reverts if module is not added ", async () => {
-      const { avatar, modifier } = await setupTestWithTestAvatar();
+      const { avatar, modifier } = await txSetup();
       const disable = await modifier.populateTransaction.disableModule(
         ZeroAddress,
         user1.address
@@ -76,7 +235,7 @@ describe("RolesModifier", async () => {
     });
 
     it("disables a module()", async () => {
-      const { avatar, modifier } = await setupTestWithTestAvatar();
+      const { avatar, modifier } = await txSetup();
       const enable = await modifier.populateTransaction.enableModule(
         user1.address
       );
@@ -98,14 +257,14 @@ describe("RolesModifier", async () => {
 
   describe("enableModule()", async () => {
     it("reverts if not authorized", async () => {
-      const { modifier } = await setupTestWithTestAvatar();
+      const { modifier } = await txSetup();
       await expect(modifier.enableModule(user1.address)).to.be.revertedWith(
         "Ownable: caller is not the owner"
       );
     });
 
     it("reverts if module is already enabled", async () => {
-      const { avatar, modifier } = await setupTestWithTestAvatar();
+      const { avatar, modifier } = await txSetup();
       const enable = await modifier.populateTransaction.enableModule(
         user1.address
       );
@@ -117,7 +276,7 @@ describe("RolesModifier", async () => {
     });
 
     it("reverts if module is invalid ", async () => {
-      const { avatar, modifier } = await setupTestWithTestAvatar();
+      const { avatar, modifier } = await txSetup();
       const enable = await modifier.populateTransaction.enableModule(
         FirstAddress
       );
@@ -128,7 +287,7 @@ describe("RolesModifier", async () => {
     });
 
     it("enables a module", async () => {
-      const { avatar, modifier } = await setupTestWithTestAvatar();
+      const { avatar, modifier } = await txSetup();
       const enable = await modifier.populateTransaction.enableModule(
         user1.address
       );
@@ -145,14 +304,14 @@ describe("RolesModifier", async () => {
 
   describe("assignRoles()", () => {
     it("reverts if not authorized", async () => {
-      const { modifier } = await setupTestWithTestAvatar();
+      const { modifier } = await txSetup();
       await expect(modifier.assignRoles(user1.address, [1])).to.be.revertedWith(
         "Ownable: caller is not the owner"
       );
     });
 
     it("assigns roles to a module", async () => {
-      const { avatar, modifier } = await setupTestWithTestAvatar();
+      const { avatar, modifier } = await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
         [1]
@@ -165,7 +324,7 @@ describe("RolesModifier", async () => {
     });
 
     it("it enables the module if necessary", async () => {
-      const { avatar, modifier } = await setupTestWithTestAvatar();
+      const { avatar, modifier } = await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
         [1]
@@ -186,7 +345,7 @@ describe("RolesModifier", async () => {
     });
 
     it("emits the AssignRoles event", async () => {
-      const { avatar, modifier } = await setupTestWithTestAvatar();
+      const { avatar, modifier } = await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
         [1]
@@ -200,8 +359,7 @@ describe("RolesModifier", async () => {
 
   describe("execTransactionFromModule", () => {
     it("reverts if called from module not assigned any role", async () => {
-      const { avatar, modifier, testContract } =
-        await setupTestWithTestAvatar();
+      const { avatar, modifier, testContract } = await txSetup();
 
       const allowTargetAddress =
         await modifier.populateTransaction.setTargetAddressAllowed(
@@ -227,8 +385,7 @@ describe("RolesModifier", async () => {
     });
 
     it("reverts if the call is not an allowed target", async () => {
-      const { avatar, modifier, testContract } =
-        await setupTestWithTestAvatar();
+      const { avatar, modifier, testContract } = await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
         [1]
@@ -255,8 +412,7 @@ describe("RolesModifier", async () => {
     });
 
     it("executes a call to an allowed target", async () => {
-      const { avatar, modifier, testContract } =
-        await setupTestWithTestAvatar();
+      const { avatar, modifier, testContract } = await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
         [1]
@@ -294,8 +450,8 @@ describe("RolesModifier", async () => {
     });
 
     it("reverts if value parameter is not allowed", async () => {
-      const { avatar, modifier, testContract } =
-        await setupTestWithTestAvatar();
+      const { avatar, modifier, testContract, paramAllowed_1, paramAllowed_2 } =
+        await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
         [1]
@@ -345,36 +501,7 @@ describe("RolesModifier", async () => {
         );
       await avatar.exec(modifier.address, 0, paramScoped.data);
 
-      const encodedParam_1 = ethers.utils.defaultAbiCoder.encode(
-        ["address"],
-        [user1.address]
-      );
-
-      const paramAllowed_1 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x40c10f19",
-          0,
-          encodedParam_1,
-          "0x"
-        );
       await avatar.exec(modifier.address, 0, paramAllowed_1.data);
-
-      const encodedParam_2 = ethers.utils.defaultAbiCoder.encode(
-        ["uint256"],
-        [99]
-      );
-
-      const paramAllowed_2 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x40c10f19",
-          1,
-          encodedParam_2,
-          "0x"
-        );
       await avatar.exec(modifier.address, 0, paramAllowed_2.data);
 
       const mint = await testContract.populateTransaction.mint(
@@ -395,8 +522,8 @@ describe("RolesModifier", async () => {
     it("executes a call with allowed value parameter", async () => {
       const user1 = (await hre.ethers.getSigners())[0];
 
-      const { avatar, modifier, testContract } =
-        await setupTestWithTestAvatar();
+      const { avatar, modifier, testContract, paramAllowed_1, paramAllowed_2 } =
+        await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
         [1]
@@ -446,36 +573,7 @@ describe("RolesModifier", async () => {
         );
       await avatar.exec(modifier.address, 0, paramScoped.data);
 
-      const encodedParam_1 = ethers.utils.defaultAbiCoder.encode(
-        ["address"],
-        [user1.address]
-      );
-
-      const paramAllowed_1 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x40c10f19",
-          0,
-          encodedParam_1,
-          "0x"
-        );
       await avatar.exec(modifier.address, 0, paramAllowed_1.data);
-
-      const encodedParam_2 = ethers.utils.defaultAbiCoder.encode(
-        ["uint256"],
-        [99]
-      );
-
-      const paramAllowed_2 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x40c10f19",
-          1,
-          encodedParam_2,
-          "0x"
-        );
       await avatar.exec(modifier.address, 0, paramAllowed_2.data);
 
       const mint = await testContract.populateTransaction.mint(
@@ -494,8 +592,18 @@ describe("RolesModifier", async () => {
     });
 
     it("reverts dynamic parameter is not allowed", async () => {
-      const { avatar, modifier, testContract } =
-        await setupTestWithTestAvatar();
+      const {
+        avatar,
+        modifier,
+        testContract,
+        paramAllowed_3,
+        paramAllowed_4,
+        paramAllowed_5,
+        paramAllowed_6,
+        paramAllowed_7,
+        paramAllowed_8,
+        paramAllowed_9,
+      } = await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
         [1]
@@ -546,113 +654,13 @@ describe("RolesModifier", async () => {
         );
       await avatar.exec(modifier.address, 0, paramScoped.data);
 
-      const encodedParam_1 = ethers.utils.solidityPack(
-        ["string"],
-        ["This is a dynamic array"]
-      );
-
-      const encodedParam_2 = ethers.utils.defaultAbiCoder.encode(
-        ["uint256"],
-        [4]
-      );
-
-      const encodedParam_3 = ethers.utils.solidityPack(
-        ["string"],
-        ["Test"]
-      );
-
-      const encodedParam_4 = ethers.utils.defaultAbiCoder.encode(
-        ["bool"],
-        [true]
-      );
-
-      const encodedParam_5 = ethers.utils.defaultAbiCoder.encode(
-        ["uint8"],
-        [3]
-      );
-
-      const encodedParam_6 = ethers.utils.solidityPack(
-        ["string"],
-        ["weeeeeeee"]
-      );
-
-      const encodedParam_7 = ethers.utils.solidityPack(
-        ["string"],
-        [
-          "This is an input that is larger than 32 bytes and must be scanned for correctness",
-        ]
-      );
-
-      const paramAllowed_1 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x273454bf",
-          0,
-          encodedParam_1,
-          "0x"
-        );
-      const paramAllowed_2 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x273454bf",
-          1,
-          encodedParam_2,
-          "0x"
-        );
-      const paramAllowed_3 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x273454bf",
-          2,
-          encodedParam_3,
-          "0x"
-        );
-      const paramAllowed_4 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x273454bf",
-          3,
-          encodedParam_4,
-          "0x"
-        );
-      const paramAllowed_5 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x273454bf",
-          4,
-          encodedParam_5,
-          "0x"
-        );
-      const paramAllowed_6 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x273454bf",
-          5,
-          encodedParam_6,
-          "0x"
-        );
-      const paramAllowed_7 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x273454bf",
-          6,
-          encodedParam_7,
-          "0x"
-        );
-      await avatar.exec(modifier.address, 0, paramAllowed_1.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_2.data);
       await avatar.exec(modifier.address, 0, paramAllowed_3.data);
       await avatar.exec(modifier.address, 0, paramAllowed_4.data);
       await avatar.exec(modifier.address, 0, paramAllowed_5.data);
       await avatar.exec(modifier.address, 0, paramAllowed_6.data);
       await avatar.exec(modifier.address, 0, paramAllowed_7.data);
+      await avatar.exec(modifier.address, 0, paramAllowed_8.data);
+      await avatar.exec(modifier.address, 0, paramAllowed_9.data);
 
       const dynamic = await testContract.populateTransaction.testDynamic(
         "This is a dynamic array that is not allowed",
@@ -675,8 +683,18 @@ describe("RolesModifier", async () => {
     });
 
     it("executes a call with allowed dynamic parameter", async () => {
-      const { avatar, modifier, testContract } =
-        await setupTestWithTestAvatar();
+      const {
+        avatar,
+        modifier,
+        testContract,
+        paramAllowed_3,
+        paramAllowed_4,
+        paramAllowed_5,
+        paramAllowed_6,
+        paramAllowed_7,
+        paramAllowed_8,
+        paramAllowed_9,
+      } = await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
         [1]
@@ -727,114 +745,13 @@ describe("RolesModifier", async () => {
         );
       await avatar.exec(modifier.address, 0, paramScoped.data);
 
-      const encodedParam_1 = ethers.utils.solidityPack(
-        ["string"],
-        ["This is a dynamic array"]
-      );
-
-      const encodedParam_2 = ethers.utils.defaultAbiCoder.encode(
-        ["uint256"],
-        [4]
-      );
-
-      const encodedParam_3 = ethers.utils.solidityPack(
-        ["string"],
-        ["Test"]
-      );
-
-      const encodedParam_4 = ethers.utils.defaultAbiCoder.encode(
-        ["bool"],
-        [true]
-      );
-
-      const encodedParam_5 = ethers.utils.defaultAbiCoder.encode(
-        ["uint8"],
-        [3]
-      );
-
-      const encodedParam_6 = ethers.utils.solidityPack(
-        ["string"],
-        ["weeeeeeee"]
-      );
-
-      const encodedParam_7 = ethers.utils.solidityPack(
-        ["string"],
-        [
-          "This is an input that is larger than 32 bytes and must be scanned for correctness",
-        ]
-      );
-
-      const paramAllowed_1 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x273454bf",
-          0,
-          encodedParam_1,
-          "0x"
-        );
-      const paramAllowed_2 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x273454bf",
-          1,
-          encodedParam_2,
-          "0x"
-        );
-      const paramAllowed_3 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x273454bf",
-          2,
-          encodedParam_3,
-          "0x"
-        );
-      const paramAllowed_4 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x273454bf",
-          3,
-          encodedParam_4,
-          "0x"
-        );
-      const paramAllowed_5 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x273454bf",
-          4,
-          encodedParam_5,
-          "0x"
-        );
-      const paramAllowed_6 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x273454bf",
-          5,
-          encodedParam_6,
-          "0x"
-        );
-      const paramAllowed_7 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x273454bf",
-          6,
-          encodedParam_7,
-          "0x"
-        );
-
-      await avatar.exec(modifier.address, 0, paramAllowed_1.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_2.data);
       await avatar.exec(modifier.address, 0, paramAllowed_3.data);
       await avatar.exec(modifier.address, 0, paramAllowed_4.data);
       await avatar.exec(modifier.address, 0, paramAllowed_5.data);
       await avatar.exec(modifier.address, 0, paramAllowed_6.data);
       await avatar.exec(modifier.address, 0, paramAllowed_7.data);
+      await avatar.exec(modifier.address, 0, paramAllowed_8.data);
+      await avatar.exec(modifier.address, 0, paramAllowed_9.data);
 
       const dynamic = await testContract.populateTransaction.testDynamic(
         "This is a dynamic array",
@@ -856,9 +773,24 @@ describe("RolesModifier", async () => {
       ).to.emit(testContract, "TestDynamic");
     });
 
-    it("executes a call with multisend tx", async () => {
-      const { avatar, modifier, testContract } =
-        await setupTestWithTestAvatar();
+    it("reverts a call with multisend tx", async () => {
+      const {
+        avatar,
+        modifier,
+        testContract,
+        paramAllowed_1,
+        paramAllowed_2,
+        paramAllowed_3,
+        paramAllowed_4,
+        paramAllowed_5,
+        paramAllowed_6,
+        paramAllowed_7,
+        paramAllowed_8,
+        paramAllowed_9,
+        tx_1,
+        tx_2,
+        tx_3,
+      } = await txSetup();
       const MultiSend = await hre.ethers.getContractFactory("MultiSend");
       const multisend = await MultiSend.deploy();
 
@@ -904,8 +836,6 @@ describe("RolesModifier", async () => {
         );
       await avatar.exec(modifier.address, 0, functionAllowed.data);
 
-      // -----
-
       const functionScoped_2 =
         await modifier.populateTransaction.setFunctionScoped(
           1,
@@ -922,8 +852,6 @@ describe("RolesModifier", async () => {
           true
         );
       await avatar.exec(modifier.address, 0, functionAllowed_2.data);
-
-      // -----
 
       const paramScoped =
         await modifier.populateTransaction.setParametersScoped(
@@ -949,160 +877,8 @@ describe("RolesModifier", async () => {
         );
       await avatar.exec(modifier.address, 0, paramScoped_2.data);
 
-      // -----
-
-      const encodedParam_1 = ethers.utils.defaultAbiCoder.encode(
-        ["address"],
-        [user1.address]
-      );
-
-      const paramAllowed_1 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x40c10f19",
-          0,
-          encodedParam_1,
-          "0x"
-        );
       await avatar.exec(modifier.address, 0, paramAllowed_1.data);
-
-      const encodedParam_2 = ethers.utils.defaultAbiCoder.encode(
-        ["uint256"],
-        [99]
-      );
-
-      const paramAllowed_2 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x40c10f19",
-          1,
-          encodedParam_2,
-          "0x"
-        );
       await avatar.exec(modifier.address, 0, paramAllowed_2.data);
-
-      // -----
-
-      const mint = await testContract.populateTransaction.mint(
-        user1.address,
-        99
-      );
-      const tx_1 = buildContractCall(
-        testContract,
-        "mint",
-        [user1.address, 99],
-        0
-      );
-      const tx_2 = buildContractCall(
-        testContract,
-        "mint",
-        [user1.address, 99],
-        0
-      );
-
-      // -----
-
-      const encodedParam_3 = ethers.utils.solidityPack(
-        ["string"],
-        ["This is a dynamic array"]
-      );
-
-      const encodedParam_4 = ethers.utils.defaultAbiCoder.encode(
-        ["uint256"],
-        [4]
-      );
-
-      const encodedParam_5 = ethers.utils.solidityPack(
-        ["string"],
-        ["Test"]
-      );
-
-      const encodedParam_6 = ethers.utils.defaultAbiCoder.encode(
-        ["bool"],
-        [true]
-      );
-
-      const encodedParam_7 = ethers.utils.defaultAbiCoder.encode(
-        ["uint8"],
-        [3]
-      );
-
-      const encodedParam_8 = ethers.utils.solidityPack(
-        ["string"],
-        ["weeeeeeee"]
-      );
-
-      const encodedParam_9 = ethers.utils.solidityPack(
-        ["string"],
-        [
-          "This is an input that is larger than 32 bytes and must be scanned for correctness",
-        ]
-      );
-      const paramAllowed_3 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x273454bf",
-          0,
-          encodedParam_3,
-          "0x"
-        );
-      const paramAllowed_4 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x273454bf",
-          1,
-          encodedParam_4,
-          "0x"
-        );
-      const paramAllowed_5 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x273454bf",
-          2,
-          encodedParam_5,
-          "0x"
-        );
-      const paramAllowed_6 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x273454bf",
-          3,
-          encodedParam_6,
-          "0x"
-        );
-      const paramAllowed_7 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x273454bf",
-          4,
-          encodedParam_7,
-          "0x"
-        );
-      const paramAllowed_8 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x273454bf",
-          5,
-          encodedParam_8,
-          "0x"
-        );
-      const paramAllowed_9 =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x273454bf",
-          6,
-          encodedParam_9,
-          "0x"
-        );
       await avatar.exec(modifier.address, 0, paramAllowed_3.data);
       await avatar.exec(modifier.address, 0, paramAllowed_4.data);
       await avatar.exec(modifier.address, 0, paramAllowed_5.data);
@@ -1111,20 +887,142 @@ describe("RolesModifier", async () => {
       await avatar.exec(modifier.address, 0, paramAllowed_8.data);
       await avatar.exec(modifier.address, 0, paramAllowed_9.data);
 
-      const tx_3 = await buildContractCall(
+      const tx_bad = buildContractCall(
         testContract,
-        "testDynamic",
-        [
-          "This is a dynamic array",
-          4,
-          "Test",
-          true,
-          3,
-          "weeeeeeee",
-          "This is an input that is larger than 32 bytes and must be scanned for correctness",
-        ],
+        "mint",
+        [user1.address, 98],
         0
       );
+
+      const multiTx = buildMultiSendSafeTx(
+        multisend,
+        [tx_1, tx_2, tx_3, tx_bad, tx_2, tx_3],
+        0
+      );
+
+      await expect(
+        modifier.execTransactionFromModule(
+          multisend.address,
+          0,
+          multiTx.data,
+          1
+        )
+      ).to.be.revertedWith("ParameterNotAllowed()");
+    });
+
+    it("executes a call with multisend tx", async () => {
+      const {
+        avatar,
+        modifier,
+        testContract,
+        paramAllowed_1,
+        paramAllowed_2,
+        paramAllowed_3,
+        paramAllowed_4,
+        paramAllowed_5,
+        paramAllowed_6,
+        paramAllowed_7,
+        paramAllowed_8,
+        paramAllowed_9,
+        tx_1,
+        tx_2,
+        tx_3,
+      } = await txSetup();
+      const MultiSend = await hre.ethers.getContractFactory("MultiSend");
+      const multisend = await MultiSend.deploy();
+
+      const assign = await modifier.populateTransaction.assignRoles(
+        user1.address,
+        [1]
+      );
+      await avatar.exec(modifier.address, 0, assign.data);
+
+      const allowTarget =
+        await modifier.populateTransaction.setTargetAddressAllowed(
+          1,
+          testContract.address,
+          true
+        );
+      await avatar.exec(modifier.address, 0, allowTarget.data);
+
+      const multiSendTarget = await modifier.populateTransaction.setMultiSend(
+        multisend.address
+      );
+      await avatar.exec(modifier.address, 0, multiSendTarget.data);
+
+      const defaultRole = await modifier.populateTransaction.setDefaultRole(
+        user1.address,
+        1
+      );
+      await avatar.exec(modifier.address, 0, defaultRole.data);
+
+      const functionScoped =
+        await modifier.populateTransaction.setFunctionScoped(
+          1,
+          testContract.address,
+          true
+        );
+      await avatar.exec(modifier.address, 0, functionScoped.data);
+
+      const functionAllowed =
+        await modifier.populateTransaction.setAllowedFunction(
+          1,
+          testContract.address,
+          "0x40c10f19",
+          true
+        );
+      await avatar.exec(modifier.address, 0, functionAllowed.data);
+
+      const functionScoped_2 =
+        await modifier.populateTransaction.setFunctionScoped(
+          1,
+          testContract.address,
+          true
+        );
+      await avatar.exec(modifier.address, 0, functionScoped_2.data);
+
+      const functionAllowed_2 =
+        await modifier.populateTransaction.setAllowedFunction(
+          1,
+          testContract.address,
+          "0x273454bf",
+          true
+        );
+      await avatar.exec(modifier.address, 0, functionAllowed_2.data);
+
+      const paramScoped =
+        await modifier.populateTransaction.setParametersScoped(
+          1,
+          testContract.address,
+          "0x40c10f19",
+          true,
+          [true, true],
+          [false, false],
+          [0, 0]
+        );
+      await avatar.exec(modifier.address, 0, paramScoped.data);
+
+      const paramScoped_2 =
+        await modifier.populateTransaction.setParametersScoped(
+          1,
+          testContract.address,
+          "0x273454bf",
+          true,
+          [true, true, true, true, true, true, true],
+          [true, false, true, false, false, true, true],
+          [0, 0, 0, 0, 0, 0, 0]
+        );
+      await avatar.exec(modifier.address, 0, paramScoped_2.data);
+
+      await avatar.exec(modifier.address, 0, paramAllowed_1.data);
+      await avatar.exec(modifier.address, 0, paramAllowed_2.data);
+      await avatar.exec(modifier.address, 0, paramAllowed_3.data);
+      await avatar.exec(modifier.address, 0, paramAllowed_4.data);
+      await avatar.exec(modifier.address, 0, paramAllowed_5.data);
+      await avatar.exec(modifier.address, 0, paramAllowed_6.data);
+      await avatar.exec(modifier.address, 0, paramAllowed_7.data);
+      await avatar.exec(modifier.address, 0, paramAllowed_8.data);
+      await avatar.exec(modifier.address, 0, paramAllowed_9.data);
 
       const multiTx = buildMultiSendSafeTx(
         multisend,
@@ -1145,8 +1043,7 @@ describe("RolesModifier", async () => {
 
   describe("execTransactionFromModuleReturnData", () => {
     it("reverts if called from module not assigned any role", async () => {
-      const { avatar, modifier, testContract } =
-        await setupTestWithTestAvatar();
+      const { avatar, modifier, testContract } = await txSetup();
 
       const allowTargetAddress =
         await modifier.populateTransaction.setTargetAddressAllowed(
@@ -1172,8 +1069,7 @@ describe("RolesModifier", async () => {
     });
 
     it("reverts if the call is not an allowed target", async () => {
-      const { avatar, modifier, testContract } =
-        await setupTestWithTestAvatar();
+      const { avatar, modifier, testContract } = await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
         [1]
@@ -1205,8 +1101,7 @@ describe("RolesModifier", async () => {
     });
 
     it("executes a call to an allowed target", async () => {
-      const { avatar, modifier, testContract } =
-        await setupTestWithTestAvatar();
+      const { avatar, modifier, testContract } = await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
         [1]

--- a/test/Roles.spec.ts
+++ b/test/Roles.spec.ts
@@ -325,6 +325,26 @@ describe("RolesModifier", async () => {
       );
     });
 
+    it("revokes roles to a module", async () => {
+      const { avatar, modifier } = await txSetup();
+      const assign = await modifier.populateTransaction.assignRoles(
+        user1.address,
+        [1],
+        [true]
+      );
+      await avatar.exec(modifier.address, 0, assign.data);
+      const revoke = await modifier.populateTransaction.assignRoles(
+        user1.address,
+        [1],
+        [false]
+      );
+      await avatar.exec(modifier.address, 0, revoke.data);
+
+      await expect(await modifier.isRoleMember(user1.address, 1)).to.be.equal(
+        false
+      );
+    });
+
     it("it enables the module if necessary", async () => {
       const { avatar, modifier } = await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(

--- a/test/Roles.spec.ts
+++ b/test/Roles.spec.ts
@@ -1039,6 +1039,342 @@ describe("RolesModifier", async () => {
         )
       ).to.emit(testContract, "TestDynamic");
     });
+
+    it("reverts if value parameter is less than allowed", async () => {
+      const { avatar, modifier, testContract, paramAllowed_1, paramAllowed_2 } =
+        await txSetup();
+      const assign = await modifier.populateTransaction.assignRoles(
+        user1.address,
+        [1]
+      );
+      await avatar.exec(modifier.address, 0, assign.data);
+
+      const allowTarget =
+        await modifier.populateTransaction.setTargetAddressAllowed(
+          1,
+          testContract.address,
+          true
+        );
+      await avatar.exec(modifier.address, 0, allowTarget.data);
+
+      const defaultRole = await modifier.populateTransaction.setDefaultRole(
+        user1.address,
+        1
+      );
+      await avatar.exec(modifier.address, 0, defaultRole.data);
+
+      const functionScoped =
+        await modifier.populateTransaction.setFunctionScoped(
+          1,
+          testContract.address,
+          true
+        );
+      await avatar.exec(modifier.address, 0, functionScoped.data);
+
+      const functionAllowed =
+        await modifier.populateTransaction.setAllowedFunction(
+          1,
+          testContract.address,
+          "0x40c10f19",
+          true
+        );
+      await avatar.exec(modifier.address, 0, functionAllowed.data);
+
+      const encodedParam_2 = ethers.utils.defaultAbiCoder.encode(
+        ["uint256"],
+        [99]
+      );
+      const paramAllowed_lessThan =
+        await modifier.populateTransaction.setParameterAllowedValue(
+          1,
+          testContract.address,
+          "0x40c10f19",
+          1,
+          encodedParam_2,
+          encodedParam_2
+        );
+
+      const paramScoped =
+        await modifier.populateTransaction.setParametersScoped(
+          1,
+          testContract.address,
+          "0x40c10f19",
+          true,
+          [true, true],
+          [false, false],
+          [0, 1] // set param 2 to greater than
+        );
+      await avatar.exec(modifier.address, 0, paramScoped.data);
+
+      await avatar.exec(modifier.address, 0, paramAllowed_1.data);
+      await avatar.exec(modifier.address, 0, paramAllowed_lessThan.data);
+
+      const mint = await testContract.populateTransaction.mint(
+        user1.address,
+        98
+      );
+
+      await expect(
+        modifier.execTransactionFromModule(
+          testContract.address,
+          0,
+          mint.data,
+          0
+        )
+      ).to.be.revertedWith("ParameterLessThanAllowed");
+    });
+
+    it("executes if value parameter is greater than allowed", async () => {
+      const { avatar, modifier, testContract, paramAllowed_1, paramAllowed_2 } =
+        await txSetup();
+      const assign = await modifier.populateTransaction.assignRoles(
+        user1.address,
+        [1]
+      );
+      await avatar.exec(modifier.address, 0, assign.data);
+
+      const allowTarget =
+        await modifier.populateTransaction.setTargetAddressAllowed(
+          1,
+          testContract.address,
+          true
+        );
+      await avatar.exec(modifier.address, 0, allowTarget.data);
+
+      const defaultRole = await modifier.populateTransaction.setDefaultRole(
+        user1.address,
+        1
+      );
+      await avatar.exec(modifier.address, 0, defaultRole.data);
+
+      const functionScoped =
+        await modifier.populateTransaction.setFunctionScoped(
+          1,
+          testContract.address,
+          true
+        );
+      await avatar.exec(modifier.address, 0, functionScoped.data);
+
+      const functionAllowed =
+        await modifier.populateTransaction.setAllowedFunction(
+          1,
+          testContract.address,
+          "0x40c10f19",
+          true
+        );
+      await avatar.exec(modifier.address, 0, functionAllowed.data);
+
+      const encodedParam_2 = ethers.utils.defaultAbiCoder.encode(
+        ["uint256"],
+        [99]
+      );
+      const paramAllowed_lessThan =
+        await modifier.populateTransaction.setParameterAllowedValue(
+          1,
+          testContract.address,
+          "0x40c10f19",
+          1,
+          encodedParam_2,
+          encodedParam_2
+        );
+
+      const paramScoped =
+        await modifier.populateTransaction.setParametersScoped(
+          1,
+          testContract.address,
+          "0x40c10f19",
+          true,
+          [true, true],
+          [false, false],
+          [0, 1] // set param 2 to greater than
+        );
+      await avatar.exec(modifier.address, 0, paramScoped.data);
+
+      await avatar.exec(modifier.address, 0, paramAllowed_1.data);
+      await avatar.exec(modifier.address, 0, paramAllowed_lessThan.data);
+
+      const mint = await testContract.populateTransaction.mint(
+        user1.address,
+        100
+      );
+
+      await expect(
+        modifier.execTransactionFromModule(
+          testContract.address,
+          0,
+          mint.data,
+          0
+        )
+      ).to.emit(testContract, "Mint");
+    });
+
+    it("reverts if value parameter is greater than allowed", async () => {
+      const { avatar, modifier, testContract, paramAllowed_1, paramAllowed_2 } =
+        await txSetup();
+      const assign = await modifier.populateTransaction.assignRoles(
+        user1.address,
+        [1]
+      );
+      await avatar.exec(modifier.address, 0, assign.data);
+
+      const allowTarget =
+        await modifier.populateTransaction.setTargetAddressAllowed(
+          1,
+          testContract.address,
+          true
+        );
+      await avatar.exec(modifier.address, 0, allowTarget.data);
+
+      const defaultRole = await modifier.populateTransaction.setDefaultRole(
+        user1.address,
+        1
+      );
+      await avatar.exec(modifier.address, 0, defaultRole.data);
+
+      const functionScoped =
+        await modifier.populateTransaction.setFunctionScoped(
+          1,
+          testContract.address,
+          true
+        );
+      await avatar.exec(modifier.address, 0, functionScoped.data);
+
+      const functionAllowed =
+        await modifier.populateTransaction.setAllowedFunction(
+          1,
+          testContract.address,
+          "0x40c10f19",
+          true
+        );
+      await avatar.exec(modifier.address, 0, functionAllowed.data);
+
+      const encodedParam_2 = ethers.utils.defaultAbiCoder.encode(
+        ["uint256"],
+        [99]
+      );
+      const paramAllowed_lessThan =
+        await modifier.populateTransaction.setParameterAllowedValue(
+          1,
+          testContract.address,
+          "0x40c10f19",
+          1,
+          encodedParam_2,
+          encodedParam_2
+        );
+
+      const paramScoped =
+        await modifier.populateTransaction.setParametersScoped(
+          1,
+          testContract.address,
+          "0x40c10f19",
+          true,
+          [true, true],
+          [false, false],
+          [0, 2] // set param 2 to less than
+        );
+      await avatar.exec(modifier.address, 0, paramScoped.data);
+
+      await avatar.exec(modifier.address, 0, paramAllowed_1.data);
+      await avatar.exec(modifier.address, 0, paramAllowed_lessThan.data);
+
+      const mint = await testContract.populateTransaction.mint(
+        user1.address,
+        100
+      );
+
+      await expect(
+        modifier.execTransactionFromModule(
+          testContract.address,
+          0,
+          mint.data,
+          0
+        )
+      ).to.be.revertedWith("ParameterGreaterThanAllowed");
+    });
+
+    it("executes if value parameter is less than allowed", async () => {
+      const { avatar, modifier, testContract, paramAllowed_1, paramAllowed_2 } =
+        await txSetup();
+      const assign = await modifier.populateTransaction.assignRoles(
+        user1.address,
+        [1]
+      );
+      await avatar.exec(modifier.address, 0, assign.data);
+
+      const allowTarget =
+        await modifier.populateTransaction.setTargetAddressAllowed(
+          1,
+          testContract.address,
+          true
+        );
+      await avatar.exec(modifier.address, 0, allowTarget.data);
+
+      const defaultRole = await modifier.populateTransaction.setDefaultRole(
+        user1.address,
+        1
+      );
+      await avatar.exec(modifier.address, 0, defaultRole.data);
+
+      const functionScoped =
+        await modifier.populateTransaction.setFunctionScoped(
+          1,
+          testContract.address,
+          true
+        );
+      await avatar.exec(modifier.address, 0, functionScoped.data);
+
+      const functionAllowed =
+        await modifier.populateTransaction.setAllowedFunction(
+          1,
+          testContract.address,
+          "0x40c10f19",
+          true
+        );
+      await avatar.exec(modifier.address, 0, functionAllowed.data);
+
+      const encodedParam_2 = ethers.utils.defaultAbiCoder.encode(
+        ["uint256"],
+        [99]
+      );
+      const paramAllowed_lessThan =
+        await modifier.populateTransaction.setParameterAllowedValue(
+          1,
+          testContract.address,
+          "0x40c10f19",
+          1,
+          encodedParam_2,
+          encodedParam_2
+        );
+
+      const paramScoped =
+        await modifier.populateTransaction.setParametersScoped(
+          1,
+          testContract.address,
+          "0x40c10f19",
+          true,
+          [true, true],
+          [false, false],
+          [0, 2] // set param 2 to less than
+        );
+      await avatar.exec(modifier.address, 0, paramScoped.data);
+
+      await avatar.exec(modifier.address, 0, paramAllowed_1.data);
+      await avatar.exec(modifier.address, 0, paramAllowed_lessThan.data);
+
+      const mint = await testContract.populateTransaction.mint(
+        user1.address,
+        98
+      );
+
+      await expect(
+        modifier.execTransactionFromModule(
+          testContract.address,
+          0,
+          mint.data,
+          0
+        )
+      ).to.emit(testContract, "Mint");
+    });
   });
 
   describe("execTransactionFromModuleReturnData", () => {

--- a/test/Roles.spec.ts
+++ b/test/Roles.spec.ts
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import hre, { deployments, waffle, ethers } from "hardhat";
 import "@nomiclabs/hardhat-ethers";
 import { buildContractCall, buildMultiSendSafeTx } from "./utils";
+import { AddressOne } from "@gnosis.pm/safe-contracts";
 const ZeroState =
   "0x0000000000000000000000000000000000000000000000000000000000000000";
 const ZeroAddress = "0x0000000000000000000000000000000000000000";
@@ -305,7 +306,7 @@ describe("RolesModifier", async () => {
   describe("assignRoles()", () => {
     it("reverts if not authorized", async () => {
       const { modifier } = await txSetup();
-      await expect(modifier.assignRoles(user1.address, [1])).to.be.revertedWith(
+      await expect(modifier.assignRoles(user1.address, [1], [true])).to.be.revertedWith(
         "Ownable: caller is not the owner"
       );
     });
@@ -314,7 +315,8 @@ describe("RolesModifier", async () => {
       const { avatar, modifier } = await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
-        [1]
+        [1],
+        [true]
       );
       await avatar.exec(modifier.address, 0, assign.data);
 
@@ -327,7 +329,8 @@ describe("RolesModifier", async () => {
       const { avatar, modifier } = await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
-        [1]
+        [1],
+        [true]
       );
       await avatar.exec(modifier.address, 0, assign.data);
 
@@ -338,7 +341,8 @@ describe("RolesModifier", async () => {
       // it doesn't revert when assigning additional roles
       const assignSecond = await modifier.populateTransaction.assignRoles(
         user1.address,
-        [1, 2]
+        [1, 2],
+        [true, true]
       );
       await expect(avatar.exec(modifier.address, 0, assignSecond.data)).to.not
         .be.reverted;
@@ -348,7 +352,8 @@ describe("RolesModifier", async () => {
       const { avatar, modifier } = await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
-        [1]
+        [1],
+        [true]
       );
 
       await expect(avatar.exec(modifier.address, 0, assign.data))
@@ -357,7 +362,7 @@ describe("RolesModifier", async () => {
     });
   });
 
-  describe("execTransactionFromModule", () => {
+  describe("execTransactionFromModule()", () => {
     it("reverts if called from module not assigned any role", async () => {
       const { avatar, modifier, testContract } = await txSetup();
 
@@ -388,7 +393,8 @@ describe("RolesModifier", async () => {
       const { avatar, modifier, testContract } = await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
-        [1]
+        [1],
+        [true]
       );
       await avatar.exec(modifier.address, 0, assign.data);
 
@@ -415,7 +421,8 @@ describe("RolesModifier", async () => {
       const { avatar, modifier, testContract } = await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
-        [1]
+        [1],
+        [true]
       );
       await avatar.exec(modifier.address, 0, assign.data);
 
@@ -454,7 +461,8 @@ describe("RolesModifier", async () => {
         await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
-        [1]
+        [1],
+        [true]
       );
       await avatar.exec(modifier.address, 0, assign.data);
 
@@ -473,7 +481,7 @@ describe("RolesModifier", async () => {
       await avatar.exec(modifier.address, 0, defaultRole.data);
 
       const functionScoped =
-        await modifier.populateTransaction.setFunctionScoped(
+        await modifier.populateTransaction.setTargetAddressScoped(
           1,
           testContract.address,
           true
@@ -526,7 +534,8 @@ describe("RolesModifier", async () => {
         await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
-        [1]
+        [1],
+        [true]
       );
       await avatar.exec(modifier.address, 0, assign.data);
 
@@ -545,7 +554,7 @@ describe("RolesModifier", async () => {
       await avatar.exec(modifier.address, 0, defaultRole.data);
 
       const functionScoped =
-        await modifier.populateTransaction.setFunctionScoped(
+        await modifier.populateTransaction.setTargetAddressScoped(
           1,
           testContract.address,
           true
@@ -606,7 +615,8 @@ describe("RolesModifier", async () => {
       } = await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
-        [1]
+        [1],
+        [true]
       );
 
       await avatar.exec(modifier.address, 0, assign.data);
@@ -626,7 +636,7 @@ describe("RolesModifier", async () => {
       await avatar.exec(modifier.address, 0, defaultRole.data);
 
       const functionScoped =
-        await modifier.populateTransaction.setFunctionScoped(
+        await modifier.populateTransaction.setTargetAddressScoped(
           1,
           testContract.address,
           true
@@ -697,7 +707,8 @@ describe("RolesModifier", async () => {
       } = await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
-        [1]
+        [1],
+        [true]
       );
 
       await avatar.exec(modifier.address, 0, assign.data);
@@ -717,7 +728,7 @@ describe("RolesModifier", async () => {
       await avatar.exec(modifier.address, 0, defaultRole.data);
 
       const functionScoped =
-        await modifier.populateTransaction.setFunctionScoped(
+        await modifier.populateTransaction.setTargetAddressScoped(
           1,
           testContract.address,
           true
@@ -796,7 +807,8 @@ describe("RolesModifier", async () => {
 
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
-        [1]
+        [1],
+        [true]
       );
       await avatar.exec(modifier.address, 0, assign.data);
 
@@ -820,7 +832,7 @@ describe("RolesModifier", async () => {
       await avatar.exec(modifier.address, 0, defaultRole.data);
 
       const functionScoped =
-        await modifier.populateTransaction.setFunctionScoped(
+        await modifier.populateTransaction.setTargetAddressScoped(
           1,
           testContract.address,
           true
@@ -837,7 +849,7 @@ describe("RolesModifier", async () => {
       await avatar.exec(modifier.address, 0, functionAllowed.data);
 
       const functionScoped_2 =
-        await modifier.populateTransaction.setFunctionScoped(
+        await modifier.populateTransaction.setTargetAddressScoped(
           1,
           testContract.address,
           true
@@ -933,7 +945,8 @@ describe("RolesModifier", async () => {
 
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
-        [1]
+        [1],
+        [true]
       );
       await avatar.exec(modifier.address, 0, assign.data);
 
@@ -957,7 +970,7 @@ describe("RolesModifier", async () => {
       await avatar.exec(modifier.address, 0, defaultRole.data);
 
       const functionScoped =
-        await modifier.populateTransaction.setFunctionScoped(
+        await modifier.populateTransaction.setTargetAddressScoped(
           1,
           testContract.address,
           true
@@ -974,7 +987,7 @@ describe("RolesModifier", async () => {
       await avatar.exec(modifier.address, 0, functionAllowed.data);
 
       const functionScoped_2 =
-        await modifier.populateTransaction.setFunctionScoped(
+        await modifier.populateTransaction.setTargetAddressScoped(
           1,
           testContract.address,
           true
@@ -1045,7 +1058,8 @@ describe("RolesModifier", async () => {
         await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
-        [1]
+        [1],
+        [true]
       );
       await avatar.exec(modifier.address, 0, assign.data);
 
@@ -1064,7 +1078,7 @@ describe("RolesModifier", async () => {
       await avatar.exec(modifier.address, 0, defaultRole.data);
 
       const functionScoped =
-        await modifier.populateTransaction.setFunctionScoped(
+        await modifier.populateTransaction.setTargetAddressScoped(
           1,
           testContract.address,
           true
@@ -1129,7 +1143,8 @@ describe("RolesModifier", async () => {
         await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
-        [1]
+        [1],
+        [true]
       );
       await avatar.exec(modifier.address, 0, assign.data);
 
@@ -1148,7 +1163,7 @@ describe("RolesModifier", async () => {
       await avatar.exec(modifier.address, 0, defaultRole.data);
 
       const functionScoped =
-        await modifier.populateTransaction.setFunctionScoped(
+        await modifier.populateTransaction.setTargetAddressScoped(
           1,
           testContract.address,
           true
@@ -1213,7 +1228,8 @@ describe("RolesModifier", async () => {
         await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
-        [1]
+        [1],
+        [true]
       );
       await avatar.exec(modifier.address, 0, assign.data);
 
@@ -1232,7 +1248,7 @@ describe("RolesModifier", async () => {
       await avatar.exec(modifier.address, 0, defaultRole.data);
 
       const functionScoped =
-        await modifier.populateTransaction.setFunctionScoped(
+        await modifier.populateTransaction.setTargetAddressScoped(
           1,
           testContract.address,
           true
@@ -1297,7 +1313,8 @@ describe("RolesModifier", async () => {
         await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
-        [1]
+        [1],
+        [true]
       );
       await avatar.exec(modifier.address, 0, assign.data);
 
@@ -1316,7 +1333,7 @@ describe("RolesModifier", async () => {
       await avatar.exec(modifier.address, 0, defaultRole.data);
 
       const functionScoped =
-        await modifier.populateTransaction.setFunctionScoped(
+        await modifier.populateTransaction.setTargetAddressScoped(
           1,
           testContract.address,
           true
@@ -1377,7 +1394,7 @@ describe("RolesModifier", async () => {
     });
   });
 
-  describe("execTransactionFromModuleReturnData", () => {
+  describe("execTransactionFromModuleReturnData()", () => {
     it("reverts if called from module not assigned any role", async () => {
       const { avatar, modifier, testContract } = await txSetup();
 
@@ -1408,7 +1425,8 @@ describe("RolesModifier", async () => {
       const { avatar, modifier, testContract } = await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
-        [1]
+        [1],
+        [true]
       );
       await avatar.exec(modifier.address, 0, assign.data);
 
@@ -1440,7 +1458,8 @@ describe("RolesModifier", async () => {
       const { avatar, modifier, testContract } = await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
-        [1]
+        [1],
+        [true]
       );
       await avatar.exec(modifier.address, 0, assign.data);
 
@@ -1472,6 +1491,232 @@ describe("RolesModifier", async () => {
           0
         )
       ).to.emit(testContract, "Mint");
+    });
+  });
+  describe("setMultiSend()", () => {
+    it("reverts if not authorized", async () => {
+      const { avatar, modifier } = await txSetup();
+      expect(modifier.setMultiSend(AddressOne, true)).to.be.revertedWith('Ownable: caller is not the owner');
+    });
+
+    it("sets multisend address to true", async () => {
+      const { avatar, modifier} = await txSetup();
+      const tx = await modifier.populateTransaction.setMultiSend(AddressOne, true);
+      expect(avatar.exec(modifier.address, 0, tx.data));
+      expect(await modifier.isAllowedMultiSend(AddressOne)).to.be.equals(true);
+    });
+
+    it("sets multisend address to false", async () => {
+      const { avatar, modifier } = await txSetup();
+      const txTrue = await modifier.populateTransaction.setMultiSend(AddressOne, true);
+      expect(avatar.exec(modifier.address, 0, txTrue.data));
+      expect(await modifier.isAllowedMultiSend(AddressOne)).to.be.equals(true);
+      const txFalse = await modifier.populateTransaction.setMultiSend(AddressOne, false);
+      expect(avatar.exec(modifier.address, 0, txFalse.data));
+      expect(await modifier.isAllowedMultiSend(AddressOne)).to.be.equals(false);
+    });
+
+    it("emits event with correct params", async () => {
+      const { avatar, modifier } = await txSetup();
+      const tx = await modifier.populateTransaction.setMultiSend(AddressOne, true);
+      expect(await avatar.exec(modifier.address, 0, tx.data))
+      .to.emit(modifier, "SetMulitSendAddress")
+      .withArgs(AddressOne, true);
+    });
+  });
+
+  describe("setTargetAddressAllowed()", () => {
+    it("reverts if not authorized", async () => {
+      const { avatar, modifier } = await txSetup();
+      expect(modifier.setTargetAddressAllowed(1, AddressOne, true)).to.be.revertedWith('Ownable: caller is not the owner');
+    });
+
+    it("sets allowed address to true", async () => {
+      const { avatar, modifier} = await txSetup();
+      const tx = await modifier.populateTransaction.setTargetAddressAllowed(1, AddressOne, true);
+      expect(avatar.exec(modifier.address, 0, tx.data));
+      expect(await modifier.isAllowedTargetAddress(1, AddressOne)).to.be.equals(true);
+    });
+
+    it("sets allowed address to false", async () => {
+      const { avatar, modifier } = await txSetup();
+      const txTrue = await modifier.populateTransaction.setTargetAddressAllowed(1, AddressOne, true);
+      expect(avatar.exec(modifier.address, 0, txTrue.data));
+      expect(await modifier.isAllowedTargetAddress(1, AddressOne)).to.be.equals(true);
+      const txFalse = await modifier.populateTransaction.setTargetAddressAllowed(1, AddressOne, false);
+      expect(avatar.exec(modifier.address, 0, txFalse.data));
+      expect(await modifier.isAllowedTargetAddress(1, AddressOne)).to.be.equals(false);
+    });
+
+    it("emits event with correct params", async () => {
+      const { avatar, modifier } = await txSetup();
+      const tx = await modifier.populateTransaction.setTargetAddressAllowed(1, AddressOne, true);
+      expect(await avatar.exec(modifier.address, 0, tx.data))
+      .to.emit(modifier, "SetTargetAddressAllowed")
+      .withArgs(1, AddressOne, true);
+    });
+  });
+
+  describe("setDelegateCallAllowedOnTargetAddress()", () => {
+    it("reverts if not authorized", async () => {
+      const { avatar, modifier } = await txSetup();
+      expect(modifier.setDelegateCallAllowedOnTargetAddress(1, AddressOne, true)).to.be.revertedWith('Ownable: caller is not the owner');
+    });
+
+    it("sets allowed address to true", async () => {
+      const { avatar, modifier} = await txSetup();
+      const tx = await modifier.populateTransaction.setDelegateCallAllowedOnTargetAddress(1, AddressOne, true);
+      expect(avatar.exec(modifier.address, 0, tx.data));
+      expect(await modifier.isAllowedToDelegateCall(1, AddressOne)).to.be.equals(true);
+    });
+
+    it("sets allowed address to false", async () => {
+      const { avatar, modifier } = await txSetup();
+      const txTrue = await modifier.populateTransaction.setDelegateCallAllowedOnTargetAddress(1, AddressOne, true);
+      expect(avatar.exec(modifier.address, 0, txTrue.data));
+      expect(await modifier.isAllowedToDelegateCall(1, AddressOne)).to.be.equals(true);
+      const txFalse = await modifier.populateTransaction.setDelegateCallAllowedOnTargetAddress(1, AddressOne, false);
+      expect(avatar.exec(modifier.address, 0, txFalse.data));
+      expect(await modifier.isAllowedToDelegateCall(1, AddressOne)).to.be.equals(false);
+    });
+
+    it("emits event with correct params", async () => {
+      const { avatar, modifier } = await txSetup();
+      const tx = await modifier.populateTransaction.setDelegateCallAllowedOnTargetAddress(1, AddressOne, true);
+      expect(await avatar.exec(modifier.address, 0, tx.data))
+      .to.emit(modifier, "SetDelegateCallAllowedOnTargetAddress")
+      .withArgs(1, AddressOne, true);
+    });
+  });
+
+  describe("setTargetAddressScoped()", () => {
+    it("reverts if not authorized", async () => {
+      const { avatar, modifier } = await txSetup();
+      expect(modifier.setTargetAddressScoped(1, AddressOne, true)).to.be.revertedWith('Ownable: caller is not the owner');
+    });
+
+    it("sets address scoped to true", async () => {
+      const { avatar, modifier} = await txSetup();
+      const tx = await modifier.populateTransaction.setTargetAddressScoped(1, AddressOne, true);
+      expect(avatar.exec(modifier.address, 0, tx.data));
+      expect(await modifier.isScoped(1, AddressOne)).to.be.equals(true);
+    });
+    
+    it("sets address scoped to false", async () => {
+      const { avatar, modifier } = await txSetup();
+      const txTrue = await modifier.populateTransaction.setTargetAddressScoped(1, AddressOne, true);
+      expect(avatar.exec(modifier.address, 0, txTrue.data));
+      expect(await modifier.isScoped(1, AddressOne)).to.be.equals(true);
+      const txFalse = await modifier.populateTransaction.setTargetAddressScoped(1, AddressOne, false);
+      expect(avatar.exec(modifier.address, 0, txFalse.data));
+      expect(await modifier.isScoped(1, AddressOne)).to.be.equals(false);
+    });
+
+    it("emits event with correct params", async () => {
+      const { avatar, modifier } = await txSetup();
+      const tx = await modifier.populateTransaction.setTargetAddressScoped(1, AddressOne, true);
+      expect(avatar.exec(modifier.address, 0, tx.data))
+      .to.emit(modifier, "SetTargetAddressScoped")
+      .withArgs(1, AddressOne, true);
+    });
+  });
+
+  describe("setParametersScoped()", () => {
+    it("reverts if not authorized", async () => {
+      const { avatar, modifier } = await txSetup();
+      expect(modifier.setParametersScoped(1, AddressOne, "0x12345678", true, [true, true], [true, true], [1,1])).to.be.revertedWith('Ownable: caller is not the owner');
+    });
+
+    it("sets parameters scoped to true", async () => {
+      const { avatar, modifier} = await txSetup();
+      const txTrue = await modifier.populateTransaction.setParametersScoped(1, AddressOne, "0x12345678", true, [true, true], [true, true], [1,1]);
+      expect(avatar.exec(modifier.address, 0, txTrue.data));
+      expect((await modifier.getParameterScopes(1, AddressOne, "0x12345678")).toString()).to.be.equals('true,true,true,true,true,1,1');
+    });
+    
+    it("sets parameters scoped to false", async () => {
+      const { avatar, modifier } = await txSetup();
+      const txTrue = await modifier.populateTransaction.setParametersScoped(1, AddressOne, "0x12345678", true, [true, true], [true, true], [1,1]);
+      expect(avatar.exec(modifier.address, 0, txTrue.data));
+      expect((await modifier.getParameterScopes(1, AddressOne, "0x12345678")).toString()).to.be.equals('true,true,true,true,true,1,1');
+      const txFalse = await modifier.populateTransaction.setParametersScoped(1, AddressOne, "0x12345678", false, [false, false], [false, false], [0,0]);
+      expect(avatar.exec(modifier.address, 0, txFalse.data));
+      expect((await modifier.getParameterScopes(1, AddressOne, "0x12345678")).toString()).to.be.equals('false,false,false,false,false,0,0');
+    });
+
+    it("emits event with correct params", async () => {
+      const { avatar, modifier } = await txSetup();
+      
+      const tx = await modifier.populateTransaction
+      .setParametersScoped(1, AddressOne, "0x12345678", true, [true, true], [true, true], [1,1]);
+      
+      expect(avatar.exec(modifier.address, 0, tx.data))
+      .to.emit(modifier, "SetParametersScoped")
+      .withArgs(1, AddressOne, "0x12345678", true, [true, true], [true, true], [1,1]);
+    });
+  });
+
+  describe("setSendAllowedOnTargetAddress()", () => {
+    it("reverts if not authorized", async () => {
+      const { avatar, modifier } = await txSetup();
+      expect(modifier.setSendAllowedOnTargetAddress(1, AddressOne, true)).to.be.revertedWith('Ownable: caller is not the owner');
+    });
+
+    it("sets allowed address to true", async () => {
+      const { avatar, modifier} = await txSetup();
+      const tx = await modifier.populateTransaction.setSendAllowedOnTargetAddress(1, AddressOne, true);
+      expect(avatar.exec(modifier.address, 0, tx.data));
+      expect(await modifier.isSendAllowed(1, AddressOne)).to.be.equals(true);
+    });
+
+    it("sets allowed address to false", async () => {
+      const { avatar, modifier } = await txSetup();
+      const txTrue = await modifier.populateTransaction.setSendAllowedOnTargetAddress(1, AddressOne, true);
+      expect(avatar.exec(modifier.address, 0, txTrue.data));
+      expect(await modifier.isSendAllowed(1, AddressOne)).to.be.equals(true);
+      const txFalse = await modifier.populateTransaction.setSendAllowedOnTargetAddress(1, AddressOne, false);
+      expect(avatar.exec(modifier.address, 0, txFalse.data));
+      expect(await modifier.isSendAllowed(1, AddressOne)).to.be.equals(false);
+    });
+
+    it("emits event with correct params", async () => {
+      const { avatar, modifier } = await txSetup();
+      const tx = await modifier.populateTransaction.setSendAllowedOnTargetAddress(1, AddressOne, true);
+      expect(await avatar.exec(modifier.address, 0, tx.data))
+      .to.emit(modifier, "SetSendAllowedOnTargetAddress")
+      .withArgs(1, AddressOne, true);
+    });
+  });
+
+  describe("setAllowedFunction()", () => {
+    it("reverts if not authorized", async () => {
+      const { avatar, modifier } = await txSetup();
+      expect(modifier.setAllowedFunction(1, AddressOne, "0x12345678", true)).to.be.revertedWith('Ownable: caller is not the owner');
+    });
+
+    it("sets allowed function to true", async () => {
+      const { avatar, modifier} = await txSetup();
+      const tx = await modifier.populateTransaction.setAllowedFunction(1, AddressOne, "0x12345678", true);
+      expect(avatar.exec(modifier.address, 0, tx.data));
+      expect(await modifier.isAllowedFunction(1, AddressOne, "0x12345678")).to.be.equals(true);
+    });
+
+    it("sets allowed function to false", async () => {
+      const { avatar, modifier } = await txSetup();
+      const txTrue = await modifier.populateTransaction.setAllowedFunction(1, AddressOne, "0x12345678", true);
+      expect(avatar.exec(modifier.address, 0, txTrue.data));
+      expect(await modifier.isAllowedFunction(1, AddressOne, "0x12345678")).to.be.equals(true);
+      const txFalse = await modifier.populateTransaction.setAllowedFunction(1, AddressOne, "0x12345678", false);
+      expect(avatar.exec(modifier.address, 0, txFalse.data));
+      expect(await modifier.isAllowedFunction(1, AddressOne, "0x12345678")).to.be.equals(false);
+    });
+
+    it("emits event with correct params", async () => {
+      const { avatar, modifier } = await txSetup();
+      const tx = await modifier.populateTransaction.setAllowedFunction(1, AddressOne, "0x12345678", true);
+      expect(await avatar.exec(modifier.address, 0, tx.data))
+      .to.emit(modifier, "SetFunctionAllowedOnTargetAddress")
+      .withArgs(1, AddressOne, "0x12345678", true);
     });
   });
 });

--- a/test/Roles.spec.ts
+++ b/test/Roles.spec.ts
@@ -1744,7 +1744,7 @@ describe("RolesModifier", async () => {
       expect(modifier.setParameterAllowedValue(1, AddressOne, "0x12345678", 1, "0xabcd", true)).to.be.revertedWith('Ownable: caller is not the owner');
     });
 
-    it("sets allowed function to true", async () => {
+    it("sets allowed parameter value to true", async () => {
       const { avatar, modifier} = await txSetup();
       const tx = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 0, "0xabcd", true);
       expect(avatar.exec(modifier.address, 0, tx.data));
@@ -1762,9 +1762,9 @@ describe("RolesModifier", async () => {
       expect(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 0, "0xabcd")).to.be.equals(true);
     });
 
-    it("sets allowed function to false", async () => {
+    it.only("sets allowed parameter value to false", async () => {
       const { avatar, modifier } = await txSetup();
-      const txTrue = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 0, "0xabcd", "0xabcd");
+      const txTrue = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 0, "0xabcd", true);
       expect(avatar.exec(modifier.address, 0, txTrue.data));
       const paramScoped =
         await modifier.populateTransaction.setParametersScoped(
@@ -1778,17 +1778,17 @@ describe("RolesModifier", async () => {
         );
       await avatar.exec(modifier.address, 0, paramScoped.data)
       expect(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 0, "0xabcd")).to.be.equals(true);
-      const txFalse = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 0, "0xabcdef", "0xabcdef");
+      const txFalse = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 0, "0xabcdef", false);
       expect(avatar.exec(modifier.address, 0, txFalse.data));
       expect(await modifier.isAllowedValueForParam(1, AddressOne, "0x12345678", 0, "0xabcd")).to.be.equals(false);
     });
 
-    it("emits event with correct params", async () => {
+    it.only("emits event with correct params", async () => {
       const { avatar, modifier } = await txSetup();
-      const tx = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 1, "0xabcd", "0xabcd");
-      expect(await avatar.exec(modifier.address, 0, tx.data))
-      .to.emit(modifier, "SetParameterAllowedValues")
-      .withArgs(1, AddressOne, "0x12345678", true);
+      const tx = await modifier.populateTransaction.setParameterAllowedValue(1, AddressOne, "0x12345678", 1, "0xabcd", true);
+      await expect(await avatar.exec(modifier.address, 0, tx.data))
+      .to.emit(modifier, "SetParameterAllowedValue")
+      .withArgs(1, AddressOne, "0x12345678", 1, true);
     });
   });
 });

--- a/test/Roles.spec.ts
+++ b/test/Roles.spec.ts
@@ -1926,14 +1926,14 @@ describe("RolesModifier", async () => {
   });
 
   describe("getCompValue()", () => {
-    it.only("returns 0 if not set", async () => {
+    it("returns 0 if not set", async () => {
       const { avatar, modifier} = await txSetup();
       const result = (await modifier.getCompValue(1, AddressOne, "0x12345678", 0)).toString();
       await expect(result).to.be.equals("0x");
     });
 
     
-    it.only("returns role if set", async () => {
+    it("returns role if set", async () => {
       const { avatar, modifier} = await txSetup();
       const tx = await modifier.populateTransaction.setParameterCompValue(1,AddressOne, "0x12345678", 0, "0x1234");
       const resultFalse = (await modifier.getCompValue(1, AddressOne, "0x12345678", 0)).toString();

--- a/test/Roles.spec.ts
+++ b/test/Roles.spec.ts
@@ -1928,7 +1928,7 @@ describe("RolesModifier", async () => {
   });
 
   describe("getCompValue()", () => {
-    it("returns 0 if not set", async () => {
+    it("returns 0x if not set", async () => {
       const { avatar, modifier} = await txSetup();
       const result = (await modifier.getCompValue(1, AddressOne, "0x12345678", 0)).toString();
       await expect(result).to.be.equals("0x");
@@ -1943,6 +1943,51 @@ describe("RolesModifier", async () => {
       await expect(await avatar.exec(modifier.address, 0, tx.data));
       const resultTrue = (await modifier.getCompValue(1, AddressOne, "0x12345678", 0)).toString();
       await expect(resultTrue).to.be.equals("0x1234");
+    });
+  });
+
+  describe("isRoleMember()", () => {
+    it("returns false if not set", async () => {
+      const { avatar, modifier} = await txSetup();
+      await expect(await modifier.isRoleMember(1, AddressOne)).to.be.equals(false);
+    });
+    
+    it("returns role if set", async () => {
+      const { avatar, modifier} = await txSetup();
+      const tx = await modifier.populateTransaction.assignRoles(user1.address, [1], [true]);
+      await expect(await modifier.isRoleMember(1, user1.address)).to.be.equals(false);
+      await expect(await avatar.exec(modifier.address, 0, tx.data));
+      await expect(await modifier.isRoleMember(1, user1.address)).to.be.equals(true);
+    });
+  });
+
+  describe("isAllowedTargetAddress()", () => {
+    it("returns false if not set", async () => {
+      const { avatar, modifier} = await txSetup();
+      await expect(await modifier.isAllowedTargetAddress(1, AddressOne)).to.be.equals(false);
+    });
+    
+    it("returns role if set", async () => {
+      const { avatar, modifier} = await txSetup();
+      await expect(await modifier.isAllowedTargetAddress(1, AddressOne)).to.be.equals(false);
+      const tx = await modifier.populateTransaction.setTargetAddressAllowed(1, AddressOne, true);
+      await expect(await avatar.exec(modifier.address, 0, tx.data));
+      await expect(await modifier.isAllowedTargetAddress(1, AddressOne)).to.be.equals(true);
+    });
+  });
+
+  describe("isScoped()", () => {
+    it("returns false if not set", async () => {
+      const { avatar, modifier} = await txSetup();
+      await expect(await modifier.isScoped(1, AddressOne)).to.be.equals(false);
+    });
+    
+    it("returns role if set", async () => {
+      const { avatar, modifier} = await txSetup();
+      await expect(await modifier.isScoped(1, AddressOne)).to.be.equals(false);
+      const tx = await modifier.populateTransaction.setTargetAddressScoped(1, AddressOne, true);
+      await expect(await avatar.exec(modifier.address, 0, tx.data));
+      await expect(await modifier.isScoped(1, AddressOne)).to.be.equals(true);
     });
   });
 });

--- a/test/Roles.spec.ts
+++ b/test/Roles.spec.ts
@@ -809,7 +809,7 @@ describe("RolesModifier", async () => {
       await avatar.exec(modifier.address, 0, allowTarget.data);
 
       const multiSendTarget = await modifier.populateTransaction.setMultiSend(
-        multisend.address
+        multisend.address, true
       );
       await avatar.exec(modifier.address, 0, multiSendTarget.data);
 
@@ -946,7 +946,7 @@ describe("RolesModifier", async () => {
       await avatar.exec(modifier.address, 0, allowTarget.data);
 
       const multiSendTarget = await modifier.populateTransaction.setMultiSend(
-        multisend.address
+        multisend.address, true
       );
       await avatar.exec(modifier.address, 0, multiSendTarget.data);
 

--- a/test/Roles.spec.ts
+++ b/test/Roles.spec.ts
@@ -320,7 +320,7 @@ describe("RolesModifier", async () => {
       );
       await avatar.exec(modifier.address, 0, assign.data);
 
-      await expect(await modifier.isRoleMember(user1.address, 1)).to.be.equal(
+      await expect(await modifier.isRoleMember(1, user1.address)).to.be.equal(
         true
       );
     });
@@ -340,7 +340,7 @@ describe("RolesModifier", async () => {
       );
       await avatar.exec(modifier.address, 0, revoke.data);
 
-      await expect(await modifier.isRoleMember(user1.address, 1)).to.be.equal(
+      await expect(await modifier.isRoleMember(1, user1.address)).to.be.equal(
         false
       );
     });
@@ -1988,6 +1988,21 @@ describe("RolesModifier", async () => {
       const tx = await modifier.populateTransaction.setTargetAddressScoped(1, AddressOne, true);
       await expect(await avatar.exec(modifier.address, 0, tx.data));
       await expect(await modifier.isScoped(1, AddressOne)).to.be.equals(true);
+    });
+  });
+
+  describe("isSendAllowed()", () => {
+    it("returns false if not set", async () => {
+      const { avatar, modifier} = await txSetup();
+      await expect(await modifier.isSendAllowed(1, AddressOne)).to.be.equals(false);
+    });
+    
+    it("returns role if set", async () => {
+      const { avatar, modifier} = await txSetup();
+      await expect(await modifier.isSendAllowed(1, AddressOne)).to.be.equals(false);
+      const tx = await modifier.populateTransaction.setSendAllowedOnTargetAddress(1, AddressOne, true);
+      await expect(await avatar.exec(modifier.address, 0, tx.data));
+      await expect(await modifier.isSendAllowed(1, AddressOne)).to.be.equals(true);
     });
   });
 });


### PR DESCRIPTION
This would solve #7. We would use these new functions from Zodiac Pilot.

This also allows specifying a role to assume for this transaction, effectively putting some use to the support of multiple roles per address (see #10).

However, there's another practical issue with supporting multiple roles per account: Since there's currently no way to query all roles assigned to an address we'd need some kind of extra database providing this information. Only then a client app, like Zodiac Pilot, would be able to automatically pick the right role when submitting a transaction.

