### PR TITLE
RevertOnFail

### DIFF
--- a/contracts/Roles.sol
+++ b/contracts/Roles.sol
@@ -941,7 +941,7 @@ contract Roles is Modifier {
         } else {
             checkTransaction(to, value, data, operation, role);
         }
-        if (revertOnFail && !exec(to, value, data, operation)) {
+        if (!exec(to, value, data, operation) && revertOnFail) {
             revert ModuleTransactionFailed();
         }
         return true;
@@ -970,7 +970,7 @@ contract Roles is Modifier {
             checkTransaction(to, value, data, operation, role);
         }
         (success, returnData) = execAndReturnData(to, value, data, operation);
-        if (revertOnFail && !success) {
+        if (!success && revertOnFail) {
             revert ModuleTransactionFailed();
         }
     }


### PR DESCRIPTION
Closes #7

This PR adds `revertOnFail` flag which is checked before returning after executing a module transaction. If `revertOnFail` is true and the internal module transaction reverts, the entire transaction will revert with the error `ModuleTransactionFailed()`.