### PR TITLE
Comp value clarity

### DIFF
--- a/contracts/Permissions.sol
+++ b/contracts/Permissions.sol
@@ -559,11 +559,7 @@ library Permissions {
         pure
         returns (Comparison)
     {
-        if (
-            isDynamic &&
-            (compType == Comparison.GreaterThan ||
-                compType == Comparison.LessThan)
-        ) {
+        if (isDynamic && compType != Comparison.OneOf) {
             return Comparison.EqualTo;
         }
 

--- a/contracts/Permissions.sol
+++ b/contracts/Permissions.sol
@@ -67,7 +67,7 @@ library Permissions {
     error UnacceptableMultiSendOffset();
 
     // must call scopeParameterAsOne
-    error OneOfNotAllowed();
+    error SettingOneOfNotAllowedInThisFunction();
 
     /*
      *
@@ -274,7 +274,7 @@ library Permissions {
 
         for(uint256 i = 0; i < paramCompType.length; i++){
             if(paramCompType[i] == Comparison.OneOf){
-                revert OneOfNotAllowed();
+                revert SettingOneOfNotAllowedInThisFunction();
             }
         }
 
@@ -309,7 +309,7 @@ library Permissions {
         bytes calldata compValue
     ) external {
         if (compType == Comparison.OneOf) {
-            revert OneOfNotAllowed();
+            revert SettingOneOfNotAllowedInThisFunction();
         }
 
         // set scopeConfig

--- a/contracts/Permissions.sol
+++ b/contracts/Permissions.sol
@@ -66,11 +66,13 @@ library Permissions {
     /// Role not allowed to use bytes greater than value for parameter
     error ParameterGreaterThanAllowed();
 
-    // only multisend txs with an offset of 32 bytes are allowed
+    /// only multisend txs with an offset of 32 bytes are allowed
     error UnacceptableMultiSendOffset();
 
+    /// OneOf Comparison must be set via dedicated function
     error UnsuitableOneOfComparison();
 
+    /// Not possible to define gt/lt for Dynamic types
     error UnsuitableRelativeComparison();
 
     /*

--- a/contracts/Permissions.sol
+++ b/contracts/Permissions.sol
@@ -253,7 +253,7 @@ library Permissions {
      * SETTERS
      *
      */
-     function scopeFunction(
+    function scopeFunction(
         Role storage role,
         address targetAddress,
         bytes4 functionSig,
@@ -262,7 +262,6 @@ library Permissions {
         Comparison[] calldata paramCompType,
         bytes[] calldata paramCompValue
     ) external {
-        
         require(
             isParamScoped.length == isParamDynamic.length,
             "Mismatch: isParamScoped and isParamDynamic length"
@@ -288,7 +287,7 @@ library Permissions {
             ] = paramCompValue[i].length > 32
                 ? keccak256(paramCompValue[i])
                 : bytes32(paramCompValue[i]);
-        }        
+        }
     }
 
     function scopeParameter(
@@ -300,7 +299,7 @@ library Permissions {
         Comparison compType,
         bytes calldata compValue
     ) external {
-         if (compType == Comparison.OneOf) {
+        if (compType == Comparison.OneOf) {
             revert OneOfNotAllowed();
         }
 
@@ -339,11 +338,7 @@ library Permissions {
         );
 
         // set compValue
-        bytes32 key = keyForCompValues(
-            targetAddress,
-            functionSig,
-            paramIndex
-        );
+        bytes32 key = keyForCompValues(targetAddress, functionSig, paramIndex);
 
         delete role.compValuesOneOf[key];
         role.compValuesOneOf[key] = new bytes32[](compValues.length);
@@ -369,18 +364,13 @@ library Permissions {
             false,
             Comparison(0)
         );
-        
+
         // set compValue
-        bytes32 key = keyForCompValues(
-            targetAddress,
-            functionSig,
-            paramIndex
-        );
+        bytes32 key = keyForCompValues(targetAddress, functionSig, paramIndex);
 
         delete role.compValues[key];
         delete role.compValuesOneOf[key];
     }
-    
 
     function resetScopeConfig(
         Role storage role,

--- a/contracts/Permissions.sol
+++ b/contracts/Permissions.sol
@@ -146,7 +146,6 @@ library Permissions {
             revert FunctionSignatureTooShort();
         }
 
-        // CLEARANCE: levels 1 2 and 3 - checks
         /*
          * For each address we have three clearance checks:
          * Forbidden     - nothing was setup
@@ -556,7 +555,6 @@ library Permissions {
         internal
         pure
     {
-        // OneOf comparison must be set explicitly, via scopeParameterAsOneOf
         if (compType == Comparison.OneOf) {
             revert UnsuitableOneOfComparison();
         }
@@ -589,11 +587,6 @@ library Permissions {
             bytes32(abi.encodePacked(targetAddress, functionSig, paramIndex));
     }
 
-    /*
-     *
-     * ALL COMPVALUE STORAGE INSERTS ARE TO PIPE THRU THIS FUNCTION
-     *
-     */
     function maybeCompressCompValue(bytes calldata compValue)
         internal
         pure

--- a/contracts/Permissions.sol
+++ b/contracts/Permissions.sol
@@ -32,9 +32,9 @@ struct Role {
 
 library Permissions {
     uint256 public constant FUNCTION_WHITELIST = 2**256 - 1;
-    // 60 bit mask
+    // 62 bit mask
     uint256 internal constant IS_SCOPED_MASK =
-        uint256(0xfffffffffffffff << 186);
+        uint256(0x3fffffffffffffff << (62 + 124));
 
     /// Function signature too short
     error FunctionSignatureTooShort();

--- a/contracts/Permissions.sol
+++ b/contracts/Permissions.sol
@@ -163,14 +163,14 @@ library Permissions {
 
         //isFunctionCheck
         if (target.clearance == Clearance.FUNCTION) {
-            uint256 paramConfig = role.functions[
+            uint256 scopeConfig = role.functions[
                 keyForFunctions(targetAddress, bytes4(data))
             ];
 
-            if (paramConfig == FUNCTION_WHITELIST) {
+            if (scopeConfig == FUNCTION_WHITELIST) {
                 return;
             } else {
-                checkParameters(role, paramConfig, targetAddress, data);
+                checkParameters(role, scopeConfig, targetAddress, data);
             }
         }
     }
@@ -181,11 +181,11 @@ library Permissions {
     /// @param data the transaction data to check
     function checkParameters(
         Role storage role,
-        uint256 paramConfig,
+        uint256 scopeConfig,
         address targetAddress,
         bytes memory data
     ) public view {
-        if (paramConfig & IS_SCOPED_MASK == 0) {
+        if (scopeConfig & IS_SCOPED_MASK == 0) {
             // is there no single param scoped?
             // either config bug or unset
             // semantically the same, not allowed
@@ -193,14 +193,14 @@ library Permissions {
         }
 
         bytes4 functionSig = bytes4(data);
-        uint8 paramCount = unpackParamCount(paramConfig);
+        uint8 paramCount = unpackParamCount(scopeConfig);
 
         for (uint8 i = 0; i < paramCount; i++) {
             (
                 bool isParamScoped,
                 bool isParamDynamic,
                 Comparison compType
-            ) = unpackParamEntry(paramConfig, i);
+            ) = unpackParamEntry(scopeConfig, i);
 
             if (!isParamScoped) {
                 continue;

--- a/contracts/Roles.sol
+++ b/contracts/Roles.sol
@@ -251,7 +251,7 @@ contract Roles is Modifier {
             roles[role],
             targetAddress,
             functionSig,
-            paramIndex,            
+            paramIndex,
             isDynamic,
             compType,
             compValue
@@ -286,7 +286,7 @@ contract Roles is Modifier {
             roles[role],
             targetAddress,
             functionSig,
-            paramIndex,            
+            paramIndex,
             isDynamic,
             compValues
         );

--- a/contracts/Roles.sol
+++ b/contracts/Roles.sol
@@ -44,7 +44,7 @@ contract Roles is Modifier {
         bool isDynamic,
         Comparison compType
     );
-  
+
     event RolesModSetup(
         address indexed initiator,
         address indexed owner,

--- a/contracts/Roles.sol
+++ b/contracts/Roles.sol
@@ -44,6 +44,20 @@ contract Roles is Modifier {
         bool isDynamic,
         Comparison compType
     );
+    event ScopeParameterAsOneOf(
+        uint16 role,
+        address targetAddress,
+        bytes4 functionSig,
+        uint8 paramIndex,
+        bool isDynamic,
+        bytes[] compValues
+    );
+    event UnscopeParameter(
+        uint16 role,
+        address targetAddress,
+        bytes4 functionSig,
+        uint8 paramIndex
+    );
 
     event RolesModSetup(
         address indexed initiator,
@@ -274,6 +288,14 @@ contract Roles is Modifier {
             isDynamic,
             compValues
         );
+        emit ScopeParameterAsOneOf(
+            role,
+            targetAddress,
+            functionSig,
+            paramIndex,
+            isDynamic,
+            compValues
+        );
     }
 
     function unscopeParameter(
@@ -288,6 +310,7 @@ contract Roles is Modifier {
             functionSig,
             paramIndex
         );
+        emit UnscopeParameter(role, targetAddress, functionSig, paramIndex);
     }
 
     /// @dev Assigns and revokes roles to a given module.

--- a/contracts/Roles.sol
+++ b/contracts/Roles.sol
@@ -169,7 +169,7 @@ contract Roles is Modifier {
         emit AllowTarget(role, targetAddress, allow);
     }
 
-    /// @dev Allows a specific function on a target address to be called.
+    /// @dev Allows a specific function, on a specific address, to be called.
     /// @notice Only callable by owner.
     /// @param role Role to set for
     /// @param targetAddress Scoped address on which a function signature should be allowed/disallowed.
@@ -191,7 +191,7 @@ contract Roles is Modifier {
         emit AllowFunction(role, targetAddress, functionSig, allow);
     }
 
-    /// @dev Sets and enforces scoping for a function on an address
+    /// @dev Sets and enforces scoping for an allowed function, on a specific address
     /// @notice Only callable by owner.
     /// @param role Role to set for.
     /// @param targetAddress Address to be scoped/unscoped.
@@ -228,7 +228,7 @@ contract Roles is Modifier {
         );
     }
 
-    /// @dev Sets and enforces scoping for a single paramater in a function on an address
+    /// @dev Sets and enforces scoping for a single parameter on an allowed function
     /// @notice Only callable by owner.
     /// @param role Role to set for.
     /// @param targetAddress Address to be scoped/unscoped.
@@ -236,6 +236,7 @@ contract Roles is Modifier {
     /// @param paramIndex the index of the parameter to scope
     /// @param isDynamic false for value, true for dynamic.
     /// @param compType Any, or EqualTo, GreaterThan, or LessThan compValue.
+    /// @param compValue The reference value used while comparing and authorizing
     function scopeParameter(
         uint16 role,
         address targetAddress,
@@ -264,14 +265,14 @@ contract Roles is Modifier {
         );
     }
 
-    /// @dev Sets and enforces scoping for a single paramater in a function on an address
+    /// @dev Sets and enforces scoping of type OneOf for a single parameter on an allowed function
     /// @notice Only callable by owner.
     /// @param role Role to set for.
     /// @param targetAddress Address to be scoped/unscoped.
     /// @param functionSig first 4 bytes of the sha256 of the function signature.
     /// @param paramIndex the index of the parameter to scope
     /// @param isDynamic false for value, true for dynamic.
-    /// @param compValues todo
+    /// @param compValues The reference values used while comparing and authorizing
     function scopeParameterAsOneOf(
         uint16 role,
         address targetAddress,
@@ -298,6 +299,13 @@ contract Roles is Modifier {
         );
     }
 
+    /// @dev Unsets scoping for a single parameter on an allowed function
+    /// @notice Only callable by owner.
+    /// @notice If no more params remain scoped after this call, the whole access to the function will be revoked.
+    /// @param role Role to set for.
+    /// @param targetAddress Address to be scoped/unscoped.
+    /// @param functionSig first 4 bytes of the sha256 of the function signature.
+    /// @param paramIndex the index of the parameter to scope
     function unscopeParameter(
         uint16 role,
         address targetAddress,

--- a/contracts/Roles.sol
+++ b/contracts/Roles.sol
@@ -44,22 +44,7 @@ contract Roles is Modifier {
         bool isDynamic,
         Comparison compType
     );
-
-    event SetParameterAllowedValue(
-        uint16 role,
-        address targetAddress,
-        bytes4 functionSig,
-        uint8 paramIndex,
-        bytes value,
-        bool allowed
-    );
-    event SetParameterCompValue(
-        uint16 role,
-        address targetAddress,
-        bytes4 functionSig,
-        uint8 paramIndex,
-        bytes compValue
-    );
+  
     event RolesModSetup(
         address indexed initiator,
         address indexed owner,

--- a/contracts/test/TestContract.sol
+++ b/contracts/test/TestContract.sol
@@ -18,6 +18,7 @@ contract TestContract {
     event FnWithSingleParam(uint256);
     event FnWithTwoParams(uint256, uint256);
     event FnWithThreeParams(uint256, uint256, uint256);
+    event FnWithTwoMixedParams(bool, string);
 
     receive() external payable {
         emit Receive();
@@ -55,6 +56,10 @@ contract TestContract {
 
     function fnWithTwoParams(uint256 a, uint256 b) public {
         emit FnWithTwoParams(a, b);
+    }
+
+    function fnWithTwoMixedParams(bool a, string calldata s) public {
+        emit FnWithTwoMixedParams(a, s);
     }
 
     function fnWithThreeParams(

--- a/test/Comparison.spec.ts
+++ b/test/Comparison.spec.ts
@@ -43,16 +43,184 @@ describe("Comparison", async () => {
     };
   });
 
+  const COMP_EQUAL = 0;
+  const COMP_GREATER = 1;
+  const COMP_LESS = 2;
+  const COMP_ONE_OF = 3;
+
+  it("enforces compType for scopeFunction", async () => {
+    const { modifier, testContract, owner } =
+      await setupRolesWithOwnerAndInvoker();
+
+    const ROLE_ID = 0;
+    const SELECTOR = testContract.interface.getSighash(
+      testContract.interface.getFunction("doNothing")
+    );
+
+    await expect(
+      modifier
+        .connect(owner)
+        .scopeFunction(
+          ROLE_ID,
+          testContract.address,
+          SELECTOR,
+          [false, true, false],
+          [false, false, false],
+          [COMP_EQUAL, COMP_ONE_OF, COMP_EQUAL],
+          ["0x", "0x", "0x"]
+        )
+    ).to.be.revertedWith("UnsuitableOneOfComparison");
+
+    await expect(
+      modifier
+        .connect(owner)
+        .scopeFunction(
+          ROLE_ID,
+          testContract.address,
+          SELECTOR,
+          [false, true, false],
+          [false, true, false],
+          [COMP_EQUAL, COMP_GREATER, COMP_GREATER],
+          ["0x", "0x", "0x"]
+        )
+    ).to.be.revertedWith("UnsuitableRelativeComparison");
+
+    await expect(
+      modifier
+        .connect(owner)
+        .scopeFunction(
+          ROLE_ID,
+          testContract.address,
+          SELECTOR,
+          [false, true, true],
+          [false, true, false],
+          [COMP_EQUAL, COMP_EQUAL, COMP_GREATER],
+          ["0x", "0x", "0x"]
+        )
+    ).to.not.be.reverted;
+
+    await expect(
+      modifier
+        .connect(owner)
+        .scopeFunction(
+          ROLE_ID,
+          testContract.address,
+          SELECTOR,
+          [false, true, true],
+          [false, true, false],
+          [COMP_EQUAL, COMP_EQUAL, COMP_LESS],
+          ["0x", "0x", "0x"]
+        )
+    ).to.not.be.reverted;
+  });
+  it("enforces compType for scopeParam", async () => {
+    const { modifier, testContract, owner } =
+      await setupRolesWithOwnerAndInvoker();
+
+    const ROLE_ID = 0;
+    const SELECTOR = testContract.interface.getSighash(
+      testContract.interface.getFunction("doNothing")
+    );
+    const IS_DYNAMIC = true;
+
+    await expect(
+      modifier
+        .connect(owner)
+        .scopeParameter(
+          ROLE_ID,
+          testContract.address,
+          SELECTOR,
+          0,
+          IS_DYNAMIC,
+          COMP_ONE_OF,
+          "0x"
+        )
+    ).to.be.revertedWith("UnsuitableOneOfComparison");
+
+    await expect(
+      modifier
+        .connect(owner)
+        .scopeParameter(
+          ROLE_ID,
+          testContract.address,
+          SELECTOR,
+          0,
+          IS_DYNAMIC,
+          COMP_GREATER,
+          "0x"
+        )
+    ).to.be.revertedWith("UnsuitableRelativeComparison");
+
+    await expect(
+      modifier
+        .connect(owner)
+        .scopeParameter(
+          ROLE_ID,
+          testContract.address,
+          SELECTOR,
+          0,
+          IS_DYNAMIC,
+          COMP_EQUAL,
+          "0x"
+        )
+    ).to.not.be.reverted;
+
+    await expect(
+      modifier
+        .connect(owner)
+        .scopeParameter(
+          ROLE_ID,
+          testContract.address,
+          SELECTOR,
+          0,
+          !IS_DYNAMIC,
+          COMP_ONE_OF,
+          "0x"
+        )
+    ).to.be.revertedWith("UnsuitableOneOfComparison");
+
+    await expect(
+      modifier
+        .connect(owner)
+        .scopeParameter(
+          ROLE_ID,
+          testContract.address,
+          SELECTOR,
+          0,
+          !IS_DYNAMIC,
+          COMP_GREATER,
+          "0x"
+        )
+    ).to.not.be.reverted;
+
+    await expect(
+      modifier
+        .connect(owner)
+        .scopeParameter(
+          ROLE_ID,
+          testContract.address,
+          SELECTOR,
+          0,
+          !IS_DYNAMIC,
+          COMP_EQUAL,
+          "0x"
+        )
+    ).to.not.be.reverted;
+  });
+
   // for the next PR
-  it("should pass an eq comparison");
-  it("should pass an eq comparison for dynamic");
-  it("should update an eq comparison");
+  it("passes an eq comparison", async () => {});
+  it("passes an eq comparison for dynamic");
+  it("re-scopes an eq compType");
 
   it("should pass a oneOf comparison");
   it("should pass a oneOf comparison for dynamic");
-  it("should update a oneOf comparison");
+  it("re-scopes a oneOf comparison to simple compType");
+  it("re-scopes simple compType to oneOf");
 
   it("should pass a gt/lt comparison");
   it("should update a gt/lt comparison");
   it("should coerce compType eq for dynamic");
+
+  it("mixed misc comparisons");
 });

--- a/test/Comparison.spec.ts
+++ b/test/Comparison.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import hre, { deployments, waffle } from "hardhat";
+import hre, { deployments, waffle, ethers } from "hardhat";
 import "@nomiclabs/hardhat-ethers";
 
 describe("Comparison", async () => {
@@ -210,11 +210,156 @@ describe("Comparison", async () => {
 
   // for the next PR
   it("passes an eq comparison", async () => {});
-  it("passes an eq comparison for dynamic");
+  it("passes an eq comparison for dynamic", async () => {
+    const { modifier, testContract, owner, invoker } =
+      await setupRolesWithOwnerAndInvoker();
+
+    const ROLE_ID = 0;
+    const SELECTOR = testContract.interface.getSighash(
+      testContract.interface.getFunction("fnWithTwoMixedParams")
+    );
+    const IS_DYNAMIC = true;
+
+    const invoke = async (a: boolean, b: string) =>
+      modifier
+        .connect(invoker)
+        .execTransactionFromModule(
+          testContract.address,
+          0,
+          (await testContract.populateTransaction.fnWithTwoMixedParams(a, b))
+            .data,
+          0
+        );
+
+    await modifier
+      .connect(owner)
+      .assignRoles(invoker.address, [ROLE_ID], [true]);
+
+    // set it to true
+    await modifier
+      .connect(owner)
+      .allowFunction(ROLE_ID, testContract.address, SELECTOR, true);
+
+    await modifier
+      .connect(owner)
+      .scopeParameter(
+        ROLE_ID,
+        testContract.address,
+        SELECTOR,
+        1,
+        IS_DYNAMIC,
+        COMP_EQUAL,
+        ethers.utils.solidityPack(["string"], ["Some string"])
+      );
+
+    await expect(invoke(false, "Some string")).to.not.be.reverted;
+
+    await expect(invoke(false, "Some other string")).to.be.revertedWith(
+      "ParameterNotAllowed()"
+    );
+  });
   it("re-scopes an eq compType");
 
-  it("should pass a oneOf comparison");
-  it("should pass a oneOf comparison for dynamic");
+  it("passes a oneOf comparison", async () => {
+    const { modifier, testContract, owner, invoker } =
+      await setupRolesWithOwnerAndInvoker();
+
+    const ROLE_ID = 0;
+    const SELECTOR = testContract.interface.getSighash(
+      testContract.interface.getFunction("fnWithSingleParam")
+    );
+
+    const invoke = async (a: number) =>
+      modifier
+        .connect(invoker)
+        .execTransactionFromModule(
+          testContract.address,
+          0,
+          (await testContract.populateTransaction.fnWithSingleParam(a)).data,
+          0
+        );
+
+    await modifier
+      .connect(owner)
+      .assignRoles(invoker.address, [ROLE_ID], [true]);
+
+    // set it to true
+    await modifier
+      .connect(owner)
+      .allowFunction(ROLE_ID, testContract.address, SELECTOR, true);
+
+    await modifier
+      .connect(owner)
+      .scopeParameterAsOneOf(
+        ROLE_ID,
+        testContract.address,
+        SELECTOR,
+        0,
+        COMP_EQUAL,
+        [
+          ethers.utils.defaultAbiCoder.encode(["uint256"], [11]),
+          ethers.utils.defaultAbiCoder.encode(["uint256"], [22]),
+        ]
+      );
+
+    await expect(invoke(11)).to.not.be.reverted;
+    await expect(invoke(22)).to.not.be.reverted;
+    await expect(invoke(33)).to.be.revertedWith("ParameterNotOneOfAllowed()");
+  });
+
+  it("passes a oneOf comparison for dynamic", async () => {
+    const { modifier, testContract, owner, invoker } =
+      await setupRolesWithOwnerAndInvoker();
+
+    const ROLE_ID = 0;
+    const IS_DYNAMIC = true;
+    const SELECTOR = testContract.interface.getSighash(
+      testContract.interface.getFunction("fnWithTwoMixedParams")
+    );
+
+    const invoke = async (a: boolean, b: string) =>
+      modifier
+        .connect(invoker)
+        .execTransactionFromModule(
+          testContract.address,
+          0,
+          (await testContract.populateTransaction.fnWithTwoMixedParams(a, b))
+            .data,
+          0
+        );
+
+    await modifier
+      .connect(owner)
+      .assignRoles(invoker.address, [ROLE_ID], [true]);
+
+    // set it to true
+    await modifier
+      .connect(owner)
+      .allowFunction(ROLE_ID, testContract.address, SELECTOR, true);
+
+    await modifier
+      .connect(owner)
+      .scopeParameterAsOneOf(
+        ROLE_ID,
+        testContract.address,
+        SELECTOR,
+        1,
+        IS_DYNAMIC,
+        [
+          ethers.utils.solidityPack(["string"], ["Hello World!"]),
+          ethers.utils.solidityPack(["string"], ["Good Morning!"]),
+          ethers.utils.solidityPack(["string"], ["gm!!!!!!!!!!!"]),
+        ]
+      );
+
+    await expect(invoke(true, "Hello World!")).to.not.be.reverted;
+    await expect(invoke(false, "Good Morning!")).to.not.be.reverted;
+    await expect(invoke(true, "gm!!!!!!!!!!!")).to.not.be.reverted;
+
+    await expect(invoke(false, "Something else")).to.be.revertedWith(
+      "ParameterNotOneOfAllowed()"
+    );
+  });
   it("re-scopes a oneOf comparison to simple compType");
   it("re-scopes simple compType to oneOf");
 

--- a/test/Roles.spec.ts
+++ b/test/Roles.spec.ts
@@ -115,73 +115,6 @@ describe("RolesModifier", async () => {
         "This is an input that is larger than 32 bytes and must be scanned for correctness",
       ]
     );
-    // const paramAllowed_3 =
-    //   await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
-    //     1,
-    //     baseAvatar.testContract.address,
-    //     "0x273454bf",
-    //     0,
-    //     encodedParam_3,
-    //     true
-    //   );
-    // const paramAllowed_4 =
-    //   await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
-    //     1,
-    //     baseAvatar.testContract.address,
-    //     "0x273454bf",
-    //     1,
-    //     encodedParam_4,
-    //     true
-    //   );
-    // const paramAllowed_5 =
-    //   await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
-    //     1,
-    //     baseAvatar.testContract.address,
-    //     "0x273454bf",
-    //     2,
-    //     encodedParam_5,
-    //     true
-    //   );
-    // const paramAllowed_6 =
-    //   await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
-    //     1,
-    //     baseAvatar.testContract.address,
-    //     "0x273454bf",
-    //     3,
-    //     encodedParam_6,
-    //     true
-    //   );
-    // const paramAllowed_7 =
-    //   await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
-    //     1,
-    //     baseAvatar.testContract.address,
-    //     "0x273454bf",
-    //     4,
-    //     encodedParam_7,
-    //     true
-    //   );
-    // const paramAllowed_8 =
-    //   await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
-    //     1,
-    //     baseAvatar.testContract.address,
-    //     "0x273454bf",
-    //     5,
-    //     encodedParam_8,
-    //     true
-    //   );
-    // const paramAllowed_9 =
-    //   await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
-    //     1,
-    //     baseAvatar.testContract.address,
-    //     "0x273454bf",
-    //     6,
-    //     encodedParam_9,
-    //     true
-    //   );
-    const mint = await baseAvatar.testContract.populateTransaction.mint(
-      user1.address,
-      99
-    );
     const tx_1 = buildContractCall(
       baseAvatar.testContract,
       "mint",
@@ -607,9 +540,6 @@ describe("RolesModifier", async () => {
       );
       await avatar.exec(modifier.address, 0, paramScoped.data);
 
-      // await avatar.exec(modifier.address, 0, paramAllowed_1.data);
-      // await avatar.exec(modifier.address, 0, paramAllowed_2.data);
-
       const mint = await testContract.populateTransaction.mint(
         user1.address,
         98
@@ -661,9 +591,6 @@ describe("RolesModifier", async () => {
         [encodedParam_1, encodedParam_2]
       );
       await avatar.exec(modifier.address, 0, paramScoped.data);
-
-      // await avatar.exec(modifier.address, 0, paramAllowed_1.data);
-      // await avatar.exec(modifier.address, 0, paramAllowed_2.data);
 
       const mint = await testContract.populateTransaction.mint(
         user1.address,

--- a/test/Roles.spec.ts
+++ b/test/Roles.spec.ts
@@ -1705,7 +1705,7 @@ describe("RolesModifier", async () => {
         AddressOne,
         "0x12345678",
         [true, true],
-        [true, true],
+        [false, false],
         [1, 1],
         [
           ethers.utils.defaultAbiCoder.encode(["uint256"], [0]),
@@ -1720,7 +1720,7 @@ describe("RolesModifier", async () => {
           AddressOne,
           "0x12345678",
           [true, true],
-          [true, true],
+          [false, false],
           [1, 1],
           [
             ethers.utils.defaultAbiCoder.encode(["uint256"], [0]),

--- a/test/Roles.spec.ts
+++ b/test/Roles.spec.ts
@@ -72,28 +72,28 @@ describe("RolesModifier", async () => {
       ["address"],
       [user1.address]
     );
-    const paramAllowed_1 =
-      await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
-        1,
-        baseAvatar.testContract.address,
-        "0x40c10f19",
-        0,
-        encodedParam_1,
-        true
-      );
+    // const paramAllowed_1 =
+    //   await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
+    //     1,
+    //     baseAvatar.testContract.address,
+    //     "0x40c10f19",
+    //     0,
+    //     encodedParam_1,
+    //     true
+    //   );
     const encodedParam_2 = ethers.utils.defaultAbiCoder.encode(
       ["uint256"],
       [99]
     );
-    const paramAllowed_2 =
-      await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
-        1,
-        baseAvatar.testContract.address,
-        "0x40c10f19",
-        1,
-        encodedParam_2,
-        true
-      );
+    // const paramAllowed_2 =
+    //   await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
+    //     1,
+    //     baseAvatar.testContract.address,
+    //     "0x40c10f19",
+    //     1,
+    //     encodedParam_2,
+    //     true
+    //   );
     const encodedParam_3 = ethers.utils.solidityPack(
       ["string"],
       ["This is a dynamic array"]
@@ -115,69 +115,69 @@ describe("RolesModifier", async () => {
         "This is an input that is larger than 32 bytes and must be scanned for correctness",
       ]
     );
-    const paramAllowed_3 =
-      await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
-        1,
-        baseAvatar.testContract.address,
-        "0x273454bf",
-        0,
-        encodedParam_3,
-        true
-      );
-    const paramAllowed_4 =
-      await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
-        1,
-        baseAvatar.testContract.address,
-        "0x273454bf",
-        1,
-        encodedParam_4,
-        true
-      );
-    const paramAllowed_5 =
-      await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
-        1,
-        baseAvatar.testContract.address,
-        "0x273454bf",
-        2,
-        encodedParam_5,
-        true
-      );
-    const paramAllowed_6 =
-      await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
-        1,
-        baseAvatar.testContract.address,
-        "0x273454bf",
-        3,
-        encodedParam_6,
-        true
-      );
-    const paramAllowed_7 =
-      await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
-        1,
-        baseAvatar.testContract.address,
-        "0x273454bf",
-        4,
-        encodedParam_7,
-        true
-      );
-    const paramAllowed_8 =
-      await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
-        1,
-        baseAvatar.testContract.address,
-        "0x273454bf",
-        5,
-        encodedParam_8,
-        true
-      );
-    const paramAllowed_9 =
-      await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
-        1,
-        baseAvatar.testContract.address,
-        "0x273454bf",
-        6,
-        encodedParam_9,
-        true
-      );
+    // const paramAllowed_3 =
+    //   await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
+    //     1,
+    //     baseAvatar.testContract.address,
+    //     "0x273454bf",
+    //     0,
+    //     encodedParam_3,
+    //     true
+    //   );
+    // const paramAllowed_4 =
+    //   await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
+    //     1,
+    //     baseAvatar.testContract.address,
+    //     "0x273454bf",
+    //     1,
+    //     encodedParam_4,
+    //     true
+    //   );
+    // const paramAllowed_5 =
+    //   await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
+    //     1,
+    //     baseAvatar.testContract.address,
+    //     "0x273454bf",
+    //     2,
+    //     encodedParam_5,
+    //     true
+    //   );
+    // const paramAllowed_6 =
+    //   await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
+    //     1,
+    //     baseAvatar.testContract.address,
+    //     "0x273454bf",
+    //     3,
+    //     encodedParam_6,
+    //     true
+    //   );
+    // const paramAllowed_7 =
+    //   await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
+    //     1,
+    //     baseAvatar.testContract.address,
+    //     "0x273454bf",
+    //     4,
+    //     encodedParam_7,
+    //     true
+    //   );
+    // const paramAllowed_8 =
+    //   await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
+    //     1,
+    //     baseAvatar.testContract.address,
+    //     "0x273454bf",
+    //     5,
+    //     encodedParam_8,
+    //     true
+    //   );
+    // const paramAllowed_9 =
+    //   await baseAvatar.modifier.populateTransaction.setParameterAllowedValue(
+    //     1,
+    //     baseAvatar.testContract.address,
+    //     "0x273454bf",
+    //     6,
+    //     encodedParam_9,
+    //     true
+    //   );
     const mint = await baseAvatar.testContract.populateTransaction.mint(
       user1.address,
       99
@@ -210,15 +210,15 @@ describe("RolesModifier", async () => {
     );
     return {
       ...baseAvatar,
-      paramAllowed_1,
-      paramAllowed_2,
-      paramAllowed_3,
-      paramAllowed_4,
-      paramAllowed_5,
-      paramAllowed_6,
-      paramAllowed_7,
-      paramAllowed_8,
-      paramAllowed_9,
+      encodedParam_1,
+      encodedParam_2,
+      encodedParam_3,
+      encodedParam_4,
+      encodedParam_5,
+      encodedParam_6,
+      encodedParam_7,
+      encodedParam_8,
+      encodedParam_9,
       tx_1,
       tx_2,
       tx_3,
@@ -573,7 +573,7 @@ describe("RolesModifier", async () => {
     });
 
     it("reverts if value parameter is not allowed", async () => {
-      const { avatar, modifier, testContract, paramAllowed_1, paramAllowed_2 } =
+      const { avatar, modifier, testContract, encodedParam_1, encodedParam_2 } =
         await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
@@ -602,12 +602,13 @@ describe("RolesModifier", async () => {
         "0x40c10f19",
         [true, true],
         [false, false],
-        [0, 0]
+        [0, 0],
+        [encodedParam_1, encodedParam_2]
       );
       await avatar.exec(modifier.address, 0, paramScoped.data);
 
-      await avatar.exec(modifier.address, 0, paramAllowed_1.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_2.data);
+      // await avatar.exec(modifier.address, 0, paramAllowed_1.data);
+      // await avatar.exec(modifier.address, 0, paramAllowed_2.data);
 
       const mint = await testContract.populateTransaction.mint(
         user1.address,
@@ -627,7 +628,7 @@ describe("RolesModifier", async () => {
     it("executes a call with allowed value parameter", async () => {
       const user1 = (await hre.ethers.getSigners())[0];
 
-      const { avatar, modifier, testContract, paramAllowed_1, paramAllowed_2 } =
+      const { avatar, modifier, testContract, encodedParam_1, encodedParam_2 } =
         await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
@@ -656,12 +657,13 @@ describe("RolesModifier", async () => {
         "0x40c10f19",
         [true, true],
         [false, false],
-        [0, 0]
+        [0, 0],
+        [encodedParam_1, encodedParam_2]
       );
       await avatar.exec(modifier.address, 0, paramScoped.data);
 
-      await avatar.exec(modifier.address, 0, paramAllowed_1.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_2.data);
+      // await avatar.exec(modifier.address, 0, paramAllowed_1.data);
+      // await avatar.exec(modifier.address, 0, paramAllowed_2.data);
 
       const mint = await testContract.populateTransaction.mint(
         user1.address,
@@ -683,13 +685,13 @@ describe("RolesModifier", async () => {
         avatar,
         modifier,
         testContract,
-        paramAllowed_3,
-        paramAllowed_4,
-        paramAllowed_5,
-        paramAllowed_6,
-        paramAllowed_7,
-        paramAllowed_8,
-        paramAllowed_9,
+        encodedParam_3,
+        encodedParam_4,
+        encodedParam_5,
+        encodedParam_6,
+        encodedParam_7,
+        encodedParam_8,
+        encodedParam_9,
       } = await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
@@ -719,17 +721,18 @@ describe("RolesModifier", async () => {
         "0x273454bf",
         [true, true, true, true, true, true, true],
         [true, false, true, false, false, true, true],
-        [0, 0, 0, 0, 0, 0, 0]
+        [0, 0, 0, 0, 0, 0, 0],
+        [
+          encodedParam_3,
+          encodedParam_4,
+          encodedParam_5,
+          encodedParam_6,
+          encodedParam_7,
+          encodedParam_8,
+          encodedParam_9,
+        ]
       );
       await avatar.exec(modifier.address, 0, paramScoped.data);
-
-      await avatar.exec(modifier.address, 0, paramAllowed_3.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_4.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_5.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_6.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_7.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_8.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_9.data);
 
       const dynamic = await testContract.populateTransaction.testDynamic(
         "This is a dynamic array that is not allowed",
@@ -756,13 +759,13 @@ describe("RolesModifier", async () => {
         avatar,
         modifier,
         testContract,
-        paramAllowed_3,
-        paramAllowed_4,
-        paramAllowed_5,
-        paramAllowed_6,
-        paramAllowed_7,
-        paramAllowed_8,
-        paramAllowed_9,
+        encodedParam_3,
+        encodedParam_4,
+        encodedParam_5,
+        encodedParam_6,
+        encodedParam_7,
+        encodedParam_8,
+        encodedParam_9,
       } = await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
@@ -792,17 +795,18 @@ describe("RolesModifier", async () => {
         "0x273454bf",
         [true, true, true, true, true, true, true],
         [true, false, true, false, false, true, true],
-        [0, 0, 0, 0, 0, 0, 0]
+        [0, 0, 0, 0, 0, 0, 0],
+        [
+          encodedParam_3,
+          encodedParam_4,
+          encodedParam_5,
+          encodedParam_6,
+          encodedParam_7,
+          encodedParam_8,
+          encodedParam_9,
+        ]
       );
       await avatar.exec(modifier.address, 0, paramScoped.data);
-
-      await avatar.exec(modifier.address, 0, paramAllowed_3.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_4.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_5.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_6.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_7.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_8.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_9.data);
 
       const dynamic = await testContract.populateTransaction.testDynamic(
         "This is a dynamic array",
@@ -829,15 +833,15 @@ describe("RolesModifier", async () => {
         avatar,
         modifier,
         testContract,
-        paramAllowed_1,
-        paramAllowed_2,
-        paramAllowed_3,
-        paramAllowed_4,
-        paramAllowed_5,
-        paramAllowed_6,
-        paramAllowed_7,
-        paramAllowed_8,
-        paramAllowed_9,
+        encodedParam_1,
+        encodedParam_2,
+        encodedParam_3,
+        encodedParam_4,
+        encodedParam_5,
+        encodedParam_6,
+        encodedParam_7,
+        encodedParam_8,
+        encodedParam_9,
         tx_1,
         tx_2,
         tx_3,
@@ -886,7 +890,8 @@ describe("RolesModifier", async () => {
         "0x40c10f19",
         [true, true],
         [false, false],
-        [0, 0]
+        [0, 0],
+        [encodedParam_1, encodedParam_2]
       );
       await avatar.exec(modifier.address, 0, paramScoped.data);
 
@@ -896,19 +901,18 @@ describe("RolesModifier", async () => {
         "0x273454bf",
         [true, true, true, true, true, true, true],
         [true, false, true, false, false, true, true],
-        [0, 0, 0, 0, 0, 0, 0]
+        [0, 0, 0, 0, 0, 0, 0],
+        [
+          encodedParam_3,
+          encodedParam_4,
+          encodedParam_5,
+          encodedParam_6,
+          encodedParam_7,
+          encodedParam_8,
+          encodedParam_9,
+        ]
       );
       await avatar.exec(modifier.address, 0, paramScoped_2.data);
-
-      await avatar.exec(modifier.address, 0, paramAllowed_1.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_2.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_3.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_4.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_5.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_6.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_7.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_8.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_9.data);
 
       const tx_bad = buildContractCall(
         testContract,
@@ -938,8 +942,8 @@ describe("RolesModifier", async () => {
         avatar,
         modifier,
         testContract,
-        paramAllowed_1,
-        paramAllowed_2,
+        encodedParam_1,
+        encodedParam_2,
         tx_1,
       } = await txSetup();
       const MultiSend = await hre.ethers.getContractFactory("MultiSend");
@@ -977,12 +981,10 @@ describe("RolesModifier", async () => {
         "0x40c10f19",
         [true, true],
         [false, false],
-        [0, 0]
+        [0, 0],
+        [encodedParam_1, encodedParam_2]
       );
       await avatar.exec(modifier.address, 0, paramScoped.data);
-
-      await avatar.exec(modifier.address, 0, paramAllowed_1.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_2.data);
 
       const multiTx = buildMultiSendSafeTx(multisend, [tx_1], 0);
 
@@ -1004,15 +1006,15 @@ describe("RolesModifier", async () => {
         avatar,
         modifier,
         testContract,
-        paramAllowed_1,
-        paramAllowed_2,
-        paramAllowed_3,
-        paramAllowed_4,
-        paramAllowed_5,
-        paramAllowed_6,
-        paramAllowed_7,
-        paramAllowed_8,
-        paramAllowed_9,
+        encodedParam_1,
+        encodedParam_2,
+        encodedParam_3,
+        encodedParam_4,
+        encodedParam_5,
+        encodedParam_6,
+        encodedParam_7,
+        encodedParam_8,
+        encodedParam_9,
         tx_1,
         tx_2,
         tx_3,
@@ -1060,7 +1062,8 @@ describe("RolesModifier", async () => {
         "0x40c10f19",
         [true, true],
         [false, false],
-        [0, 0]
+        [0, 0],
+        [encodedParam_1, encodedParam_2]
       );
       await avatar.exec(modifier.address, 0, paramScoped.data);
 
@@ -1070,19 +1073,18 @@ describe("RolesModifier", async () => {
         "0x273454bf",
         [true, true, true, true, true, true, true],
         [true, false, true, false, false, true, true],
-        [0, 0, 0, 0, 0, 0, 0]
+        [0, 0, 0, 0, 0, 0, 0],
+        [
+          encodedParam_3,
+          encodedParam_4,
+          encodedParam_5,
+          encodedParam_6,
+          encodedParam_7,
+          encodedParam_8,
+          encodedParam_9,
+        ]
       );
       await avatar.exec(modifier.address, 0, paramScoped_2.data);
-
-      await avatar.exec(modifier.address, 0, paramAllowed_1.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_2.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_3.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_4.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_5.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_6.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_7.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_8.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_9.data);
 
       const multiTx = buildMultiSendSafeTx(
         multisend,
@@ -1101,7 +1103,7 @@ describe("RolesModifier", async () => {
     });
 
     it("reverts if value parameter is less than allowed", async () => {
-      const { avatar, modifier, testContract, paramAllowed_1, paramAllowed_2 } =
+      const { avatar, modifier, testContract, encodedParam_1 } =
         await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
@@ -1128,14 +1130,6 @@ describe("RolesModifier", async () => {
         ["uint256"],
         [99]
       );
-      const paramAllowed_lessThan =
-        await modifier.populateTransaction.setParameterCompValue(
-          1,
-          testContract.address,
-          "0x40c10f19",
-          1,
-          encodedParam_2
-        );
 
       const paramScoped = await modifier.populateTransaction.scopeFunction(
         1,
@@ -1143,12 +1137,10 @@ describe("RolesModifier", async () => {
         "0x40c10f19",
         [true, true],
         [false, false],
-        [0, 1] // set param 2 to greater than
+        [0, 1],
+        [encodedParam_1, encodedParam_2] // set param 2 to greater than
       );
       await avatar.exec(modifier.address, 0, paramScoped.data);
-
-      await avatar.exec(modifier.address, 0, paramAllowed_1.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_lessThan.data);
 
       const mint = await testContract.populateTransaction.mint(
         user1.address,
@@ -1166,7 +1158,7 @@ describe("RolesModifier", async () => {
     });
 
     it("executes if value parameter is greater than allowed", async () => {
-      const { avatar, modifier, testContract, paramAllowed_1, paramAllowed_2 } =
+      const { avatar, modifier, testContract, encodedParam_1 } =
         await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
@@ -1193,15 +1185,6 @@ describe("RolesModifier", async () => {
         ["uint256"],
         [99]
       );
-      const paramAllowed_lessThan =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x40c10f19",
-          1,
-          encodedParam_2,
-          encodedParam_2
-        );
 
       const paramScoped = await modifier.populateTransaction.scopeFunction(
         1,
@@ -1209,12 +1192,10 @@ describe("RolesModifier", async () => {
         "0x40c10f19",
         [true, true],
         [false, false],
-        [0, 1] // set param 2 to greater than
+        [0, 1],
+        [encodedParam_1, encodedParam_2] // set param 2 to greater than
       );
       await avatar.exec(modifier.address, 0, paramScoped.data);
-
-      await avatar.exec(modifier.address, 0, paramAllowed_1.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_lessThan.data);
 
       const mint = await testContract.populateTransaction.mint(
         user1.address,
@@ -1232,7 +1213,7 @@ describe("RolesModifier", async () => {
     });
 
     it("reverts if value parameter is greater than allowed", async () => {
-      const { avatar, modifier, testContract, paramAllowed_1, paramAllowed_2 } =
+      const { avatar, modifier, testContract, encodedParam_1 } =
         await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
@@ -1259,15 +1240,15 @@ describe("RolesModifier", async () => {
         ["uint256"],
         [99]
       );
-      const paramAllowed_lessThan =
-        await modifier.populateTransaction.setParameterAllowedValue(
-          1,
-          testContract.address,
-          "0x40c10f19",
-          1,
-          encodedParam_2,
-          encodedParam_2
-        );
+      // const paramAllowed_lessThan =
+      //   await modifier.populateTransaction.setParameterAllowedValue(
+      //     1,
+      //     testContract.address,
+      //     "0x40c10f19",
+      //     1,
+      //     encodedParam_2,
+      //     encodedParam_2
+      //   );
 
       const paramScoped = await modifier.populateTransaction.scopeFunction(
         1,
@@ -1275,12 +1256,10 @@ describe("RolesModifier", async () => {
         "0x40c10f19",
         [true, true],
         [false, false],
-        [0, 2] // set param 2 to less than
+        [0, 2],
+        [encodedParam_1, encodedParam_2] // set param 2 to less than
       );
       await avatar.exec(modifier.address, 0, paramScoped.data);
-
-      await avatar.exec(modifier.address, 0, paramAllowed_1.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_lessThan.data);
 
       const mint = await testContract.populateTransaction.mint(
         user1.address,
@@ -1298,7 +1277,7 @@ describe("RolesModifier", async () => {
     });
 
     it("executes if value parameter is less than allowed", async () => {
-      const { avatar, modifier, testContract, paramAllowed_1 } =
+      const { avatar, modifier, testContract, encodedParam_1 } =
         await txSetup();
       const assign = await modifier.populateTransaction.assignRoles(
         user1.address,
@@ -1332,14 +1311,14 @@ describe("RolesModifier", async () => {
         ["uint256"],
         [99]
       );
-      const paramAllowed_lessThan =
-        await modifier.populateTransaction.setParameterCompValue(
-          1,
-          testContract.address,
-          "0x40c10f19",
-          1,
-          encodedParam_2
-        );
+      // const paramAllowed_lessThan =
+      //   await modifier.populateTransaction.setParameterCompValue(
+      //     1,
+      //     testContract.address,
+      //     "0x40c10f19",
+      //     1,
+      //     encodedParam_2
+      //   );
 
       const paramScoped = await modifier.populateTransaction.scopeFunction(
         1,
@@ -1347,12 +1326,10 @@ describe("RolesModifier", async () => {
         "0x40c10f19",
         [true, true],
         [false, false],
-        [0, 2] // set param 2 to less than
+        [0, 2],
+        [encodedParam_1, encodedParam_2] // set param 2 to less than
       );
       await avatar.exec(modifier.address, 0, paramScoped.data);
-
-      await avatar.exec(modifier.address, 0, paramAllowed_1.data);
-      await avatar.exec(modifier.address, 0, paramAllowed_lessThan.data);
 
       const mint = await testContract.populateTransaction.mint(
         user1.address,
@@ -1728,7 +1705,8 @@ describe("RolesModifier", async () => {
           "0x12345678",
           [true, true],
           [true, true],
-          [1, 1]
+          [1, 1],
+          ["0x", "0x"]
         )
       ).to.be.revertedWith("Ownable: caller is not the owner");
     });
@@ -1777,19 +1755,8 @@ describe("RolesModifier", async () => {
           SELECTOR,
           [true],
           [false],
-          [COMP_TYPE_EQ]
-        );
-
-      // turn scoping on
-      await modifier
-        .connect(owner)
-        .setParameterAllowedValue(
-          ROLE_ID,
-          testContract.address,
-          SELECTOR,
-          0,
-          ethers.utils.defaultAbiCoder.encode(["uint256"], [2]),
-          true
+          [COMP_TYPE_EQ],
+          [ethers.utils.defaultAbiCoder.encode(["uint256"], [2])]
         );
 
       // ngmi
@@ -1812,7 +1779,11 @@ describe("RolesModifier", async () => {
         "0x12345678",
         [true, true],
         [true, true],
-        [1, 1]
+        [1, 1],
+        [
+          ethers.utils.defaultAbiCoder.encode(["uint256"], [0]),
+          ethers.utils.defaultAbiCoder.encode(["uint256"], [0]),
+        ]
       );
 
       await expect(await avatar.exec(modifier.address, 0, tx.data))
@@ -1823,7 +1794,11 @@ describe("RolesModifier", async () => {
           "0x12345678",
           [true, true],
           [true, true],
-          [1, 1]
+          [1, 1],
+          [
+            ethers.utils.defaultAbiCoder.encode(["uint256"], [0]),
+            ethers.utils.defaultAbiCoder.encode(["uint256"], [0]),
+          ]
         );
     });
   });
@@ -1984,131 +1959,6 @@ describe("RolesModifier", async () => {
       )
         .to.emit(modifier, "AllowFunction")
         .withArgs(1, AddressOne, "0x12345678", true);
-    });
-  });
-
-  describe("setParameterAllowedValue()", () => {
-    it("reverts if not authorized", async () => {
-      const { modifier } = await txSetup();
-      expect(
-        modifier.setParameterAllowedValue(
-          1,
-          AddressOne,
-          "0x12345678",
-          1,
-          "0xabcd",
-          true
-        )
-      ).to.be.revertedWith("Ownable: caller is not the owner");
-    });
-
-    it("sets different allowed value parameters", async () => {
-      const { modifier, testContract, owner, invoker } =
-        await setupRolesWithOwnerAndInvoker();
-
-      const ROLE_ID = 0;
-      const COMP_TYPE_EQ = 0;
-      const SELECTOR = testContract.interface.getSighash(
-        testContract.interface.getFunction("fnWithTwoParams")
-      );
-      const EXEC_ARGS = (a: number, b: number) => [
-        testContract.address,
-        0,
-        testContract.interface.encodeFunctionData(
-          "fnWithTwoParams(uint256,uint256)",
-          [a, b]
-        ),
-        0,
-      ];
-
-      await modifier
-        .connect(owner)
-        .assignRoles(invoker.address, [ROLE_ID], [true]);
-
-      await modifier
-        .connect(owner)
-        .allowFunction(ROLE_ID, testContract.address, SELECTOR, true);
-
-      await modifier
-        .connect(owner)
-        .scopeFunction(
-          ROLE_ID,
-          testContract.address,
-          SELECTOR,
-          [false, true],
-          [false, false],
-          [COMP_TYPE_EQ, COMP_TYPE_EQ]
-        );
-
-      // should fail before setting an allowedValue -> compValue
-      await expect(
-        modifier
-          .connect(invoker)
-          .execTransactionFromModule(...EXEC_ARGS(10, 20))
-      ).to.be.revertedWith("ParameterNotAllowed");
-
-      await modifier
-        .connect(owner)
-        .setParameterAllowedValue(
-          ROLE_ID,
-          testContract.address,
-          SELECTOR,
-          1,
-          ethers.utils.defaultAbiCoder.encode(["uint256"], [10]),
-          true
-        );
-
-      // should fail because second param not allowed
-      await expect(
-        modifier
-          .connect(invoker)
-          .execTransactionFromModule(...EXEC_ARGS(20, 20))
-      ).to.be.revertedWith("ParameterNotAllowed");
-
-      // should succeed with allowed value
-      await expect(
-        modifier
-          .connect(invoker)
-          .execTransactionFromModule(...EXEC_ARGS(10, 10))
-      ).to.not.be.reverted;
-    });
-
-    it("emits event with correct params", async () => {
-      const { avatar, modifier } = await txSetup();
-      const tx = await modifier.populateTransaction.setParameterAllowedValue(
-        1,
-        AddressOne,
-        "0x12345678",
-        1,
-        "0xabcd",
-        true
-      );
-      await expect(await avatar.exec(modifier.address, 0, tx.data))
-        .to.emit(modifier, "SetParameterAllowedValue")
-        .withArgs(1, AddressOne, "0x12345678", 1, "0xabcd", true);
-    });
-  });
-
-  describe("setParameterCompValue()", () => {
-    it("reverts if not authorized", async () => {
-      const { modifier } = await txSetup();
-      expect(
-        modifier.setParameterCompValue(1, AddressOne, "0x12345678", 1, "0xabcd")
-      ).to.be.revertedWith("Ownable: caller is not the owner");
-    });
-
-    it("emits event with correct params", async () => {
-      const { avatar, modifier } = await txSetup();
-      const tx = await modifier.populateTransaction.setParameterCompValue(
-        1,
-        AddressOne,
-        "0x12345678",
-        1,
-        "0xabcd"
-      );
-      await expect(await avatar.exec(modifier.address, 0, tx.data))
-        .to.emit(modifier, "SetParameterCompValue")
-        .withArgs(1, AddressOne, "0x12345678", 1, "0xabcd");
     });
   });
 

--- a/test/Scoping.spec.ts
+++ b/test/Scoping.spec.ts
@@ -625,6 +625,6 @@ describe("Scoping", async () => {
       );
 
     await expect(invoke(421)).to.not.be.reverted;
-    await expect(invoke(419)).to.be.revertedWith("ParameterLessThanAllowed");
+    await expect(invoke(419)).to.be.revertedWith("ParameterLessThanAllowed()");
   });
 });

--- a/test/Scoping.spec.ts
+++ b/test/Scoping.spec.ts
@@ -43,7 +43,7 @@ describe("Scoping", async () => {
     };
   });
 
-  it("function scoping works", async () => {
+  it("scoping one param should work", async () => {
     const { modifier, testContract, owner, invoker } =
       await setupRolesWithOwnerAndInvoker();
 
@@ -60,7 +60,58 @@ describe("Scoping", async () => {
       await testContract.populateTransaction.fnWithThreeParams(1, 2, 3);
 
     const { data: dataOk } =
-      await testContract.populateTransaction.fnWithThreeParams(4, 2, 6);
+      await testContract.populateTransaction.fnWithThreeParams(1, 4, 3);
+
+    await modifier
+      .connect(owner)
+      .allowFunction(ROLE_ID, testContract.address, SELECTOR, true);
+
+    await expect(
+      modifier
+        .connect(invoker)
+        .execTransactionFromModule(testContract.address, 0, dataFail, 0)
+    ).to.not.be.reverted;
+
+    await modifier
+      .connect(owner)
+      .scopeParameter(ROLE_ID, testContract.address, SELECTOR, 1, false, 0);
+
+    await modifier
+      .connect(owner)
+      .setParameterAllowedValue(
+        ROLE_ID,
+        testContract.address,
+        SELECTOR,
+        1,
+        ethers.utils.defaultAbiCoder.encode(["uint256"], [4]),
+        true
+      );
+
+    await expect(
+      modifier
+        .connect(invoker)
+        .execTransactionFromModule(testContract.address, 0, dataFail, 0)
+    ).to.be.revertedWith("ParameterNotAllowed()");
+
+    await expect(
+      modifier
+        .connect(invoker)
+        .execTransactionFromModule(testContract.address, 0, dataOk, 0)
+    ).to.not.be.reverted;
+  });
+
+  it("unscoping one param should work", async () => {
+    const { modifier, testContract, owner, invoker } =
+      await setupRolesWithOwnerAndInvoker();
+
+    const ROLE_ID = 0;
+    const SELECTOR = testContract.interface.getSighash(
+      testContract.interface.getFunction("fnWithThreeParams")
+    );
+
+    await modifier
+      .connect(owner)
+      .assignRoles(invoker.address, [ROLE_ID], [true]);
 
     await modifier
       .connect(owner)
@@ -68,14 +119,11 @@ describe("Scoping", async () => {
 
     await modifier
       .connect(owner)
-      .scopeFunction(
-        ROLE_ID,
-        testContract.address,
-        SELECTOR,
-        [true, false, false],
-        [false, false, false],
-        [0, 0, 0]
-      );
+      .scopeParameter(ROLE_ID, testContract.address, SELECTOR, 0, false, 0);
+
+    await modifier
+      .connect(owner)
+      .scopeParameter(ROLE_ID, testContract.address, SELECTOR, 1, false, 0);
 
     await modifier
       .connect(owner)
@@ -94,21 +142,39 @@ describe("Scoping", async () => {
         ROLE_ID,
         testContract.address,
         SELECTOR,
-        2,
-        ethers.utils.defaultAbiCoder.encode(["uint256"], [6]),
+        1,
+        ethers.utils.defaultAbiCoder.encode(["uint256"], [5]),
         true
       );
 
+    const { data: dataFail } =
+      await testContract.populateTransaction.fnWithThreeParams(4, 2, 3);
+    const { data: dataOk } =
+      await testContract.populateTransaction.fnWithThreeParams(4, 5, 3);
+
+    // fails first
     await expect(
       modifier
         .connect(invoker)
         .execTransactionFromModule(testContract.address, 0, dataFail, 0)
     ).to.be.revertedWith("ParameterNotAllowed()");
 
+    // sanity check
     await expect(
       modifier
         .connect(invoker)
         .execTransactionFromModule(testContract.address, 0, dataOk, 0)
+    ).to.not.be.reverted;
+
+    await modifier
+      .connect(owner)
+      .unscopeParameter(ROLE_ID, testContract.address, SELECTOR, 1);
+
+    // works after unscoping
+    await expect(
+      modifier
+        .connect(invoker)
+        .execTransactionFromModule(testContract.address, 0, dataFail, 0)
     ).to.not.be.reverted;
   });
 
@@ -131,15 +197,7 @@ describe("Scoping", async () => {
 
     await modifier
       .connect(owner)
-      .scopeParameter(
-        ROLE_ID,
-        testContract.address,
-        SELECTOR,
-        0,
-        true,
-        false,
-        0
-      );
+      .scopeParameter(ROLE_ID, testContract.address, SELECTOR, 0, false, 0);
 
     await modifier
       .connect(owner)
@@ -178,7 +236,66 @@ describe("Scoping", async () => {
         )
     ).to.not.be.reverted;
   });
-  it("param scoping should work after revoke function", async () => {
+
+  it("scoping one param should work after allow function", async () => {
+    const { modifier, testContract, owner, invoker } =
+      await setupRolesWithOwnerAndInvoker();
+
+    const ROLE_ID = 0;
+    const SELECTOR = testContract.interface.getSighash(
+      testContract.interface.getFunction("fnWithThreeParams")
+    );
+
+    await modifier
+      .connect(owner)
+      .assignRoles(invoker.address, [ROLE_ID], [true]);
+
+    await modifier
+      .connect(owner)
+      .allowFunction(ROLE_ID, testContract.address, SELECTOR, true);
+
+    await modifier
+      .connect(owner)
+      .scopeParameter(ROLE_ID, testContract.address, SELECTOR, 0, false, 0);
+
+    await modifier
+      .connect(owner)
+      .setParameterAllowedValue(
+        ROLE_ID,
+        testContract.address,
+        SELECTOR,
+        0,
+        ethers.utils.defaultAbiCoder.encode(["uint256"], [7]),
+        true
+      );
+
+    await expect(
+      modifier
+        .connect(invoker)
+        .execTransactionFromModule(
+          testContract.address,
+          0,
+          (
+            await testContract.populateTransaction.fnWithThreeParams(1, 2, 3)
+          ).data,
+          0
+        )
+    ).to.be.revertedWith("ParameterNotAllowed()");
+
+    await expect(
+      modifier
+        .connect(invoker)
+        .execTransactionFromModule(
+          testContract.address,
+          0,
+          (
+            await testContract.populateTransaction.fnWithThreeParams(7, 2, 3)
+          ).data,
+          0
+        )
+    ).to.not.be.reverted;
+  });
+  it("scoping one param should work after revoke function", async () => {
     const { modifier, testContract, owner, invoker } =
       await setupRolesWithOwnerAndInvoker();
 
@@ -203,15 +320,7 @@ describe("Scoping", async () => {
 
     await modifier
       .connect(owner)
-      .scopeParameter(
-        ROLE_ID,
-        testContract.address,
-        SELECTOR,
-        0,
-        true,
-        false,
-        0
-      );
+      .scopeParameter(ROLE_ID, testContract.address, SELECTOR, 0, false, 0);
 
     await modifier
       .connect(owner)
@@ -250,7 +359,7 @@ describe("Scoping", async () => {
         )
     ).to.not.be.reverted;
   });
-  it("param scoping should work from scoped state", async () => {
+  it("scoping one param should work from scoped state", async () => {
     const { modifier, testContract, owner, invoker } =
       await setupRolesWithOwnerAndInvoker();
 
@@ -309,15 +418,7 @@ describe("Scoping", async () => {
     // set last param also as scoped
     await modifier
       .connect(owner)
-      .scopeParameter(
-        ROLE_ID,
-        testContract.address,
-        SELECTOR,
-        2,
-        true,
-        false,
-        0
-      );
+      .scopeParameter(ROLE_ID, testContract.address, SELECTOR, 2, false, 0);
     await modifier
       .connect(owner)
       .setParameterAllowedValue(
@@ -387,15 +488,7 @@ describe("Scoping", async () => {
 
     await modifier
       .connect(owner)
-      .scopeParameter(
-        ROLE_ID,
-        testContract.address,
-        SELECTOR,
-        0,
-        true,
-        false,
-        0
-      );
+      .scopeParameter(ROLE_ID, testContract.address, SELECTOR, 0, false, 0);
 
     await modifier
       .connect(owner)
@@ -422,7 +515,7 @@ describe("Scoping", async () => {
     ).to.be.revertedWith("FunctionNotAllowed()");
   });
 
-  it("param scoping all params off, should result in FunctionNotAllowed", async () => {
+  it("unscoping all params one by one, should result in FunctionNotAllowed", async () => {
     const { modifier, testContract, owner, invoker } =
       await setupRolesWithOwnerAndInvoker();
 
@@ -452,15 +545,7 @@ describe("Scoping", async () => {
 
     await modifier
       .connect(owner)
-      .scopeParameter(
-        ROLE_ID,
-        testContract.address,
-        SELECTOR,
-        0,
-        false,
-        false,
-        0
-      );
+      .unscopeParameter(ROLE_ID, testContract.address, SELECTOR, 0);
 
     //if some params still scoped returned ParamNotAllowed
     await expect(
@@ -478,15 +563,7 @@ describe("Scoping", async () => {
 
     await modifier
       .connect(owner)
-      .scopeParameter(
-        ROLE_ID,
-        testContract.address,
-        SELECTOR,
-        1,
-        false,
-        false,
-        0
-      );
+      .unscopeParameter(ROLE_ID, testContract.address, SELECTOR, 1);
 
     //all params off -> FunctionNotAllowed
     await expect(

--- a/test/Scoping.spec.ts
+++ b/test/Scoping.spec.ts
@@ -51,6 +51,7 @@ describe("Scoping", async () => {
     const SELECTOR = testContract.interface.getSighash(
       testContract.interface.getFunction("fnWithThreeParams")
     );
+    const COMP_EQ = 0;
 
     await modifier
       .connect(owner)
@@ -74,17 +75,14 @@ describe("Scoping", async () => {
 
     await modifier
       .connect(owner)
-      .scopeParameter(ROLE_ID, testContract.address, SELECTOR, 1, false, 0);
-
-    await modifier
-      .connect(owner)
-      .setParameterAllowedValue(
+      .scopeParameter(
         ROLE_ID,
         testContract.address,
         SELECTOR,
         1,
-        ethers.utils.defaultAbiCoder.encode(["uint256"], [4]),
-        true
+        false,
+        COMP_EQ,
+        ethers.utils.defaultAbiCoder.encode(["uint256"], [4])
       );
 
     await expect(
@@ -104,6 +102,7 @@ describe("Scoping", async () => {
     const { modifier, testContract, owner, invoker } =
       await setupRolesWithOwnerAndInvoker();
 
+    const COMP_EQ = 0;
     const ROLE_ID = 0;
     const SELECTOR = testContract.interface.getSighash(
       testContract.interface.getFunction("fnWithThreeParams")
@@ -119,32 +118,26 @@ describe("Scoping", async () => {
 
     await modifier
       .connect(owner)
-      .scopeParameter(ROLE_ID, testContract.address, SELECTOR, 0, false, 0);
-
-    await modifier
-      .connect(owner)
-      .scopeParameter(ROLE_ID, testContract.address, SELECTOR, 1, false, 0);
-
-    await modifier
-      .connect(owner)
-      .setParameterAllowedValue(
+      .scopeParameter(
         ROLE_ID,
         testContract.address,
         SELECTOR,
         0,
-        ethers.utils.defaultAbiCoder.encode(["uint256"], [4]),
-        true
+        false,
+        COMP_EQ,
+        ethers.utils.defaultAbiCoder.encode(["uint256"], [4])
       );
 
     await modifier
       .connect(owner)
-      .setParameterAllowedValue(
+      .scopeParameter(
         ROLE_ID,
         testContract.address,
         SELECTOR,
         1,
-        ethers.utils.defaultAbiCoder.encode(["uint256"], [5]),
-        true
+        false,
+        COMP_EQ,
+        ethers.utils.defaultAbiCoder.encode(["uint256"], [5])
       );
 
     const { data: dataFail } =
@@ -186,6 +179,7 @@ describe("Scoping", async () => {
     const SELECTOR = testContract.interface.getSighash(
       testContract.interface.getFunction("fnWithThreeParams")
     );
+    const COMP_EQ = 0;
 
     await modifier
       .connect(owner)
@@ -197,17 +191,14 @@ describe("Scoping", async () => {
 
     await modifier
       .connect(owner)
-      .scopeParameter(ROLE_ID, testContract.address, SELECTOR, 0, false, 0);
-
-    await modifier
-      .connect(owner)
-      .setParameterAllowedValue(
+      .scopeParameter(
         ROLE_ID,
         testContract.address,
         SELECTOR,
         0,
-        ethers.utils.defaultAbiCoder.encode(["uint256"], [7]),
-        true
+        false,
+        COMP_EQ,
+        ethers.utils.defaultAbiCoder.encode(["uint256"], [7])
       );
 
     await expect(
@@ -245,6 +236,7 @@ describe("Scoping", async () => {
     const SELECTOR = testContract.interface.getSighash(
       testContract.interface.getFunction("fnWithThreeParams")
     );
+    const COMP_EQ = 0;
 
     await modifier
       .connect(owner)
@@ -256,17 +248,14 @@ describe("Scoping", async () => {
 
     await modifier
       .connect(owner)
-      .scopeParameter(ROLE_ID, testContract.address, SELECTOR, 0, false, 0);
-
-    await modifier
-      .connect(owner)
-      .setParameterAllowedValue(
+      .scopeParameter(
         ROLE_ID,
         testContract.address,
         SELECTOR,
         0,
-        ethers.utils.defaultAbiCoder.encode(["uint256"], [7]),
-        true
+        false,
+        COMP_EQ,
+        ethers.utils.defaultAbiCoder.encode(["uint256"], [7])
       );
 
     await expect(
@@ -303,6 +292,7 @@ describe("Scoping", async () => {
     const SELECTOR = testContract.interface.getSighash(
       testContract.interface.getFunction("fnWithThreeParams")
     );
+    const COMP_EQ = 0;
 
     await modifier
       .connect(owner)
@@ -320,17 +310,14 @@ describe("Scoping", async () => {
 
     await modifier
       .connect(owner)
-      .scopeParameter(ROLE_ID, testContract.address, SELECTOR, 0, false, 0);
-
-    await modifier
-      .connect(owner)
-      .setParameterAllowedValue(
+      .scopeParameter(
         ROLE_ID,
         testContract.address,
         SELECTOR,
         0,
-        ethers.utils.defaultAbiCoder.encode(["uint256"], [7]),
-        true
+        false,
+        COMP_EQ,
+        ethers.utils.defaultAbiCoder.encode(["uint256"], [7])
       );
 
     await expect(
@@ -367,6 +354,7 @@ describe("Scoping", async () => {
     const SELECTOR = testContract.interface.getSighash(
       testContract.interface.getFunction("fnWithThreeParams")
     );
+    const COMP_EQ = 0;
 
     await modifier
       .connect(owner)
@@ -389,18 +377,8 @@ describe("Scoping", async () => {
         SELECTOR,
         [false, true, false],
         [false, false, false],
-        [0, 0, 0]
-      );
-
-    await modifier
-      .connect(owner)
-      .setParameterAllowedValue(
-        ROLE_ID,
-        testContract.address,
-        SELECTOR,
-        1,
-        ethers.utils.defaultAbiCoder.encode(["uint256"], [7]),
-        true
+        [COMP_EQ, COMP_EQ, COMP_EQ],
+        ["0x", ethers.utils.defaultAbiCoder.encode(["uint256"], [7]), "0x"]
       );
 
     await expect(
@@ -418,16 +396,14 @@ describe("Scoping", async () => {
     // set last param also as scoped
     await modifier
       .connect(owner)
-      .scopeParameter(ROLE_ID, testContract.address, SELECTOR, 2, false, 0);
-    await modifier
-      .connect(owner)
-      .setParameterAllowedValue(
+      .scopeParameter(
         ROLE_ID,
         testContract.address,
         SELECTOR,
         2,
-        ethers.utils.defaultAbiCoder.encode(["uint256"], [8]),
-        true
+        false,
+        COMP_EQ,
+        ethers.utils.defaultAbiCoder.encode(["uint256"], [8])
       );
 
     // should account for last param
@@ -477,6 +453,7 @@ describe("Scoping", async () => {
     const SELECTOR = testContract.interface.getSighash(
       testContract.interface.getFunction("fnWithThreeParams")
     );
+    const COMP_EQ = 0;
 
     await modifier
       .connect(owner)
@@ -488,7 +465,15 @@ describe("Scoping", async () => {
 
     await modifier
       .connect(owner)
-      .scopeParameter(ROLE_ID, testContract.address, SELECTOR, 0, false, 0);
+      .scopeParameter(
+        ROLE_ID,
+        testContract.address,
+        SELECTOR,
+        0,
+        false,
+        COMP_EQ,
+        "0x"
+      );
 
     await modifier
       .connect(owner)
@@ -498,7 +483,8 @@ describe("Scoping", async () => {
         SELECTOR,
         [false, false, false],
         [false, false, false],
-        [0, 0, 0]
+        [0, 0, 0],
+        ["0x", "0x", "0x"]
       );
 
     await expect(
@@ -523,6 +509,7 @@ describe("Scoping", async () => {
     const SELECTOR = testContract.interface.getSighash(
       testContract.interface.getFunction("fnWithThreeParams")
     );
+    const COMP_EQ = 0;
 
     await modifier
       .connect(owner)
@@ -540,7 +527,8 @@ describe("Scoping", async () => {
         SELECTOR,
         [true, true, false],
         [false, false, false],
-        [0, 0, 0]
+        [0, 0, 0],
+        ["0x", "0x", "0x"]
       );
 
     await modifier


### PR DESCRIPTION
This PR has the goal of simplifying the way compValues are handled in the api

Previously:
* We provided two ways to set compValues: setParameterAllowedValue and setParameterCompValue
* By Calling setParameterAllowedValue several times, the user was able to "synthesize" a comparison of type oneOf
* For relative comparisons (gt,lt), setParameterAllowed value was not considered.

This PR:
* We only have compValues - removed allowedValue
* Make oneOf an explicit comparisonType
* Change the scoping api to:
  * scopeFunction( ... )
  * scopeParamater( ... )
  * scopeParameterAsOneOf( ... )
  * uncopeParameter( ... )

Note that scoping functions now include values on the signature: no more separate calls for rules and values. 