### PR TITLE
Improve some names in the subgraph schema

### DIFF
--- a/packages/app/src/services/subgraph.ts
+++ b/packages/app/src/services/subgraph.ts
@@ -40,7 +40,7 @@ const RolesQuery = gql`
           executionOptions
           clearance
           functions {
-            functionSig
+            sighash
             executionOptions
             wildcarded
             parameters {
@@ -77,7 +77,7 @@ interface RolesQueryResponse {
         executionOptions: string
         clearance: ConditionType
         functions: {
-          functionSig: string
+          sighash: string
           executionOptions: string
           wildcarded: boolean
           parameters: {
@@ -122,12 +122,12 @@ export const fetchRoles = async (rolesModifierAddress: string): Promise<Role[]> 
               })
 
               const funcConditions: FunctionCondition = {
-                sighash: func.functionSig,
+                sighash: func.sighash,
                 type: func.wildcarded ? ConditionType.WILDCARDED : getFunctionConditionType(paramConditions),
                 executionOption: getExecutionOptionFromLabel(func.executionOptions),
                 params: paramConditions,
               }
-              return [func.functionSig, funcConditions]
+              return [func.sighash, funcConditions]
             }),
           )
           return {

--- a/packages/app/src/services/subgraph.ts
+++ b/packages/app/src/services/subgraph.ts
@@ -44,10 +44,10 @@ const RolesQuery = gql`
             executionOptions
             wildcarded
             parameters {
-              parameterIndex
-              parameterType
-              parameterComparison
-              parameterComparisonValue
+              index
+              type
+              comparison
+              comparisonValue
             }
           }
         }
@@ -81,10 +81,10 @@ interface RolesQueryResponse {
           executionOptions: string
           wildcarded: boolean
           parameters: {
-            parameterIndex: number
-            parameterType: ParameterType
-            parameterComparison: ParamComparison
-            parameterComparisonValue: string
+            index: number
+            type: ParameterType
+            comparison: ParamComparison
+            comparisonValue: string
           }[]
         }[]
       }[]
@@ -113,10 +113,10 @@ export const fetchRoles = async (rolesModifierAddress: string): Promise<Role[]> 
             target.functions.map((func) => {
               const paramConditions = func.parameters.map((param) => {
                 const paramCondition: ParamCondition = {
-                  index: param.parameterIndex,
-                  condition: param.parameterComparison,
-                  value: param.parameterComparisonValue,
-                  type: param.parameterType,
+                  index: param.index,
+                  condition: param.comparison,
+                  value: param.comparisonValue,
+                  type: param.type,
                 }
                 return paramCondition
               })

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -30,7 +30,7 @@ type Role @entity {
   rolesModifier: RolesModifier!
   roleIdInContract: Int! # The role id used to represent this role in context of the role's rolesModifier
   targets: [Target!] @derivedFrom(field: "role")
-  members: [MemberRole!] @derivedFrom(field: "role")
+  members: [RoleAssignment!] @derivedFrom(field: "role")
 }
 
 type Target @entity {
@@ -48,26 +48,26 @@ type Function @entity {
   functionSig: Bytes!
   executionOptions: ExecutionOptions!
   wildcarded: Boolean!
-  parameters: [Parameter!] @derivedFrom(field: "theFunction")
+  parameters: [Parameter!] @derivedFrom(field: "owningFunction")
 }
 
 type Parameter @entity {
   id: ID!
-  theFunction: Function!
-  parameterIndex: Int!
-  parameterType: ParameterType!
-  parameterComparison: ParameterComparison!
-  parameterComparisonValue: [Bytes!]! # Will contain only one value except for onOf the all values it can be will be in the array
+  owningFunction: Function!
+  index: Int!
+  type: ParameterType!
+  comparison: ParameterComparison!
+  comparisonValue: [Bytes!]! # Will contain only one value except for oneOf where is an array
 }
 
 type Member @entity {
   id: ID!
   address: Bytes!
   enabledAsModule: Boolean!
-  roles: [MemberRole!] @derivedFrom(field: "member")
+  roles: [RoleAssignment!] @derivedFrom(field: "member")
 }
 
-type MemberRole @entity {
+type RoleAssignment @entity {
   id: ID!
   member: Member!
   role: Role!
@@ -78,6 +78,6 @@ type RolesModifier @entity {
   address: Bytes!
   owner: Bytes!
   avatar: Bytes!
-  exec_target: Bytes!
+  target: Bytes!
   roles: [Role!] @derivedFrom(field: "rolesModifier")
 }

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -45,7 +45,7 @@ type Target @entity {
 type Function @entity {
   id: ID!
   target: Target
-  functionSig: Bytes!
+  sighash: Bytes!
   executionOptions: ExecutionOptions!
   wildcarded: Boolean!
   parameters: [Parameter!] @derivedFrom(field: "owningFunction")

--- a/packages/subgraph/src/helpers.ts
+++ b/packages/subgraph/src/helpers.ts
@@ -29,7 +29,7 @@ export const getMemberId = (rolesModifierId: string, member: Address): string =>
   rolesModifierId + "-MEMBER-" + member.toHex()
 export const getFunctionId = (targetId: string, functionSig: Bytes): string =>
   targetId + "-FUNCTION-" + functionSig.toHex()
-export const getMemberRoleId = (memberId: string, roleId: string): string => memberId + "-" + roleId
+export const getAssignmentId = (memberId: string, roleId: string): string => memberId + "-" + roleId
 export const getParameterId = (functionId: string, parameterIndex: number): string =>
   functionId + "-PARAMETER-" + parameterIndex.toString()
 

--- a/packages/subgraph/src/helpers.ts
+++ b/packages/subgraph/src/helpers.ts
@@ -27,8 +27,7 @@ export const getRoleId = (roleModifierId: string, role: number): string => roleM
 export const getTargetId = (roleId: string, target: Address): string => roleId + "-TARGET-" + target.toHex()
 export const getMemberId = (rolesModifierId: string, member: Address): string =>
   rolesModifierId + "-MEMBER-" + member.toHex()
-export const getFunctionId = (targetId: string, functionSig: Bytes): string =>
-  targetId + "-FUNCTION-" + functionSig.toHex()
+export const getFunctionId = (targetId: string, sighash: Bytes): string => targetId + "-FUNCTION-" + sighash.toHex()
 export const getAssignmentId = (memberId: string, roleId: string): string => memberId + "-" + roleId
 export const getParameterId = (functionId: string, parameterIndex: number): string =>
   functionId + "-PARAMETER-" + parameterIndex.toString()
@@ -77,13 +76,13 @@ For created Functions:
  - execution options options is None.
  - wildcarded is false.
 */
-export const getOrCreateFunction = (functionId: string, targetId: string, functionSig: Bytes): Function => {
+export const getOrCreateFunction = (functionId: string, targetId: string, sighash: Bytes): Function => {
   let theFunction = Function.load(functionId)
 
   if (!theFunction) {
     theFunction = new Function(functionId)
     theFunction.target = targetId
-    theFunction.functionSig = functionSig
+    theFunction.sighash = sighash
     theFunction.executionOptions = EXECUTION_OPTIONS[EXECUTION_OPTIONS__NONE]
     theFunction.wildcarded = false
     theFunction.save()

--- a/packages/subgraph/src/permissions.mapping.ts
+++ b/packages/subgraph/src/permissions.mapping.ts
@@ -104,9 +104,9 @@ export function handleScopeAllowFunction(event: ScopeAllowFunction): void {
   const targetId = getTargetId(roleId, targetAddress)
   const target = getOrCreateTarget(targetId, targetAddress, roleId)
 
-  const functionSig = event.params.selector
-  const functionId = getFunctionId(targetId, functionSig)
-  const theFunction = getOrCreateFunction(functionId, targetId, functionSig)
+  const sighash = event.params.selector
+  const functionId = getFunctionId(targetId, sighash)
+  const theFunction = getOrCreateFunction(functionId, targetId, sighash)
   theFunction.executionOptions = EXECUTION_OPTIONS[event.params.options]
   theFunction.wildcarded = true
   theFunction.save()
@@ -130,9 +130,9 @@ export function handleScopeFunction(event: ScopeFunction): void {
   const target = getOrCreateTarget(targetId, targetAddress, roleId)
 
   // if function does not exist? create it with the info from the event
-  const functionSig = event.params.functionSig
-  const functionId = getFunctionId(targetId, functionSig)
-  const theFunction = getOrCreateFunction(functionId, targetId, functionSig)
+  const sighash = event.params.functionSig
+  const functionId = getFunctionId(targetId, sighash)
+  const theFunction = getOrCreateFunction(functionId, targetId, sighash)
   theFunction.executionOptions = EXECUTION_OPTIONS[event.params.options]
   theFunction.save()
 
@@ -166,9 +166,9 @@ export function handleScopeFunctionExecutionOptions(event: ScopeFunctionExecutio
   const targetAddress = event.params.targetAddress
   const targetId = getTargetId(roleId, targetAddress)
   getOrCreateTarget(targetId, targetAddress, roleId)
-  const functionSig = event.params.functionSig
-  const functionId = getFunctionId(targetId, functionSig)
-  const theFunction = getOrCreateFunction(functionId, targetId, functionSig)
+  const sighash = event.params.functionSig
+  const functionId = getFunctionId(targetId, sighash)
+  const theFunction = getOrCreateFunction(functionId, targetId, sighash)
   theFunction.executionOptions = EXECUTION_OPTIONS[event.params.options]
   theFunction.save()
 }
@@ -186,9 +186,9 @@ export function handleScopeParameter(event: ScopeParameter): void {
   const targetAddress = event.params.targetAddress
   const targetId = getTargetId(roleId, targetAddress)
   getOrCreateTarget(targetId, targetAddress, roleId)
-  const functionSig = event.params.functionSig
-  const functionId = getFunctionId(targetId, functionSig)
-  const theFunction = getOrCreateFunction(functionId, targetId, functionSig)
+  const sighash = event.params.functionSig
+  const functionId = getFunctionId(targetId, sighash)
+  const theFunction = getOrCreateFunction(functionId, targetId, sighash)
 
   const parameterId = getParameterId(functionId, event.params.index.toI32())
   const parameter = new Parameter(parameterId) // will always overwrite the parameter
@@ -216,9 +216,9 @@ export function handleScopeParameterAsOneOf(event: ScopeParameterAsOneOf): void 
   const targetAddress = event.params.targetAddress
   const targetId = getTargetId(roleId, targetAddress)
   getOrCreateTarget(targetId, targetAddress, roleId)
-  const functionSig = event.params.functionSig
-  const functionId = getFunctionId(targetId, functionSig)
-  const theFunction = getOrCreateFunction(functionId, targetId, functionSig)
+  const sighash = event.params.functionSig
+  const functionId = getFunctionId(targetId, sighash)
+  const theFunction = getOrCreateFunction(functionId, targetId, sighash)
 
   const parameterId = getParameterId(functionId, event.params.index.toI32())
   const parameter = new Parameter(parameterId) // will always overwrite the parameter
@@ -241,8 +241,8 @@ export function handleScopeRevokeFunction(event: ScopeRevokeFunction): void {
   const targetAddress = event.params.targetAddress
   const roleId = getRoleId(rolesModifierId, event.params.role)
   const targetId = getTargetId(roleId, targetAddress)
-  const functionSig = event.params.selector
-  const functionId = getFunctionId(targetId, functionSig)
+  const sighash = event.params.selector
+  const functionId = getFunctionId(targetId, sighash)
 
   store.remove("Function", functionId)
 }
@@ -258,8 +258,8 @@ export function handleUnscopeParameter(event: UnscopeParameter): void {
   const roleId = getRoleId(rolesModifierId, event.params.role)
   const targetAddress = event.params.targetAddress
   const targetId = getTargetId(roleId, targetAddress)
-  const functionSig = event.params.functionSig
-  const functionId = getFunctionId(targetId, functionSig)
+  const sighash = event.params.functionSig
+  const functionId = getFunctionId(targetId, sighash)
   const parameterId = getParameterId(functionId, event.params.index.toI32())
 
   store.remove("Parameter", parameterId)

--- a/packages/subgraph/src/permissions.mapping.ts
+++ b/packages/subgraph/src/permissions.mapping.ts
@@ -144,11 +144,11 @@ export function handleScopeFunction(event: ScopeFunction): void {
 
     const parameterId = getParameterId(functionId, i)
     const parameter = new Parameter(parameterId)
-    parameter.theFunction = functionId
-    parameter.parameterIndex = i
-    parameter.parameterType = paramType
-    parameter.parameterComparison = paramComp
-    parameter.parameterComparisonValue = [compValue]
+    parameter.owningFunction = functionId
+    parameter.index = i
+    parameter.type = paramType
+    parameter.comparison = paramComp
+    parameter.comparisonValue = [compValue]
     parameter.save()
   }
 }
@@ -195,11 +195,11 @@ export function handleScopeParameter(event: ScopeParameter): void {
   const paramType = PARAMETER_TYPE[event.params.paramType]
   const paramComp = PARAMETER_COMPARISON[event.params.paramComp]
   const compValue = event.params.compValue
-  parameter.theFunction = functionId
-  parameter.parameterIndex = event.params.index.toI32()
-  parameter.parameterType = paramType
-  parameter.parameterComparison = paramComp
-  parameter.parameterComparisonValue = [compValue]
+  parameter.owningFunction = functionId
+  parameter.index = event.params.index.toI32()
+  parameter.type = paramType
+  parameter.comparison = paramComp
+  parameter.comparisonValue = [compValue]
   parameter.save()
 }
 
@@ -226,11 +226,11 @@ export function handleScopeParameterAsOneOf(event: ScopeParameterAsOneOf): void 
   const paramComp = PARAMETER_COMPARISON[PARAMETER_COMPARISON__ONE_OF]
   const compValues = event.params.compValues
 
-  parameter.theFunction = functionId
-  parameter.parameterIndex = event.params.index.toI32()
-  parameter.parameterType = paramType
-  parameter.parameterComparison = paramComp
-  parameter.parameterComparisonValue = compValues
+  parameter.owningFunction = functionId
+  parameter.index = event.params.index.toI32()
+  parameter.type = paramType
+  parameter.comparison = paramComp
+  parameter.comparisonValue = compValues
   parameter.save()
 }
 


### PR DESCRIPTION
Since I'm working on integrating the SDK with the subgraph and looking to use consistent naming I've stumbled over some names that I think could be improved in the subgraph schema. I'm proposing the following updates:

`Parameter.theFunction` -> `Parameter.owningFunction`
`Parameter.parameterIndex` -> `Parameter.index` 
`Parameter.parameterType` -> `Parameter.type` 
`Parameter.parameterComparison` -> `Parameter.comparison` 
`Parameter.parameterComparisonValue` -> `Parameter.comparisonValue` 

`Function.functionSig` -> `Function.sighash`

`MemberRole` -> `RoleAssignment` 

`RolesModifier.exec_target` -> `RolesModifier.target`

Let me know what you think, @manboy-eth... 🙌 
