### PR TITLE
fix comparison value type

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -57,6 +57,7 @@
     "getabi:permissions": "cp ../evm/build/artifacts/contracts/Permissions.sol/Permissions.json ./contracts/abi/Permissions.json",
     "getabi:roles": "cp ../evm/build/artifacts/contracts/Roles.sol/Roles.json ./contracts/abi/Roles.json",
     "prebuild": "yarn getabi:permissions && yarn getabi:roles && yarn build:types",
+    "prestart": "yarn getabi:permissions && yarn getabi:roles && yarn build:types",
     "fmt": "prettier '(test|src)/**/*.(ts|tsx)' -w",
     "pre-commit": "yarn fmt"
   },

--- a/packages/app/src/components/views/Role/targets/ParamConditionInput.tsx
+++ b/packages/app/src/components/views/Role/targets/ParamConditionInput.tsx
@@ -64,7 +64,7 @@ export const ParamConditionInput = ({ index, param, condition, disabled, onChang
   const type = getConditionType(nativeType)
   const options = getConditionsPerType(nativeType)
 
-  const handleChange = (condition: ParamComparison) => onChange({ index, type, condition, value: "" })
+  const handleChange = (condition: ParamComparison) => onChange({ index, type, condition, value: [""] })
   const handleRemove = () => onChange(undefined)
 
   if (nativeType === ParamNativeType.UNSUPPORTED) return null
@@ -72,7 +72,7 @@ export const ParamConditionInput = ({ index, param, condition, disabled, onChang
   if (!condition) {
     const handleClick = () => {
       if (nativeType === ParamNativeType.BOOLEAN) {
-        onChange({ index, type, condition: ParamComparison.EQUAL_TO, value: BooleanValue.FALSE })
+        onChange({ index, type, condition: ParamComparison.EQUAL_TO, value: [BooleanValue.FALSE] })
         return
       }
       handleChange(options[0])
@@ -92,14 +92,15 @@ export const ParamConditionInput = ({ index, param, condition, disabled, onChang
   )
 
   if (nativeType === ParamNativeType.BOOLEAN) {
-    const handleBooleanChange = (value: string) => onChange({ index, type, condition: ParamComparison.EQUAL_TO, value })
+    const handleBooleanChange = (value: string) =>
+      onChange({ index, type, condition: ParamComparison.EQUAL_TO, value: [value] })
     return (
       <>
         <Select
           classes={{ icon: classes.selectIcon }}
           className={classes.select}
           disabled={disabled}
-          value={condition.value}
+          value={condition.value[0]}
           onChange={(evt) => handleBooleanChange(evt.target.value as string)}
         >
           <MenuItem value={BooleanValue.FALSE}>is false</MenuItem>

--- a/packages/app/src/components/views/Role/targets/ParamConditionInputValue.tsx
+++ b/packages/app/src/components/views/Role/targets/ParamConditionInputValue.tsx
@@ -56,7 +56,7 @@ export const ParamConditionInputValue = ({ param, condition, disabled, onChange 
     } catch (err) {
       setValid(false)
     }
-    onChange({ ...condition, value })
+    onChange({ ...condition, value: [value] })
   }
 
   return (
@@ -68,7 +68,7 @@ export const ParamConditionInputValue = ({ param, condition, disabled, onChange 
         disableUnderline: true,
         className: classNames(classes.input, { [classes.error]: !valid && dirty }),
       }}
-      value={condition.value}
+      value={condition.value[0]}
       placeholder={getPlaceholderForType(param)}
       onChange={(evt) => handleChange(evt.target.value)}
     />

--- a/packages/app/src/services/rolesModifierContract.ts
+++ b/packages/app/src/services/rolesModifierContract.ts
@@ -213,7 +213,7 @@ export const updateRole = async (
           const param = functions[sighash].inputs[paramCondition.index]
 
           if (paramCondition.condition !== ParamComparison.ONE_OF) {
-            const value = formatParamValue(param, paramCondition.value)
+            const value = formatParamValue(param, paramCondition.value[0])
             const encodedValue = ethers.utils.defaultAbiCoder.encode([param], [value])
             console.log("[updateRole] scope parameter", [
               role.id,
@@ -233,28 +233,28 @@ export const updateRole = async (
               paramCondition.condition,
               encodedValue,
             )
+          } else {
+            const encodedValues = paramCondition.value.map((value) => {
+              return ethers.utils.defaultAbiCoder.encode([param], [formatParamValue(param, value)])
+            })
+
+            console.log("[updateRole] scope parameter as OneOf", [
+              role.id,
+              target.address,
+              sighash,
+              paramCondition.index,
+              paramCondition.type,
+              encodedValues || [],
+            ])
+            return rolesModifierContract.populateTransaction.scopeParameterAsOneOf(
+              role.id,
+              target.address,
+              sighash,
+              paramCondition.index,
+              paramCondition.type,
+              encodedValues || [],
+            )
           }
-
-          const encodedValues = paramCondition.values?.map((value) => {
-            return ethers.utils.defaultAbiCoder.encode([param], [formatParamValue(param, paramCondition.value)])
-          })
-
-          console.log("[updateRole] scope parameter as OneOf", [
-            role.id,
-            target.address,
-            sighash,
-            paramCondition.index,
-            paramCondition.type,
-            encodedValues || [],
-          ])
-          return rolesModifierContract.populateTransaction.scopeParameterAsOneOf(
-            role.id,
-            target.address,
-            sighash,
-            paramCondition.index,
-            paramCondition.type,
-            encodedValues || [],
-          )
         })
       })
       .flat()

--- a/packages/app/src/services/subgraph.ts
+++ b/packages/app/src/services/subgraph.ts
@@ -84,7 +84,7 @@ interface RolesQueryResponse {
             index: number
             type: ParameterType
             comparison: ParamComparison
-            comparisonValue: string
+            comparisonValue: string[]
           }[]
         }[]
       }[]

--- a/packages/app/src/typings/role.ts
+++ b/packages/app/src/typings/role.ts
@@ -35,8 +35,7 @@ export interface ParamCondition {
   index: number
   type: ParameterType
   condition: ParamComparison
-  value: string
-  values?: string[]
+  value: string[]
 }
 
 export enum ParamComparison {


### PR DESCRIPTION
comparison values can be single ABI encoded string (for equals, greater than and less than) or an array of of encoded strings (for one of). In the subgraph schema we chose to generally store them as string arrays, so that if only a single value is expected it will be stores as the first and only element in that array.

This PR adjusts the app types so we handle it consistently. This fixes #124 