### PR TITLE
Fix subgraph error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ packages/subgraph/abis/*.json
 
 # This will be generated from the themplate on deployment (to support multiple networks)
 packages/subgraph/subgraph.yaml
-.vscode/settings.json
+
+.vscode

--- a/packages/app/src/components/views/Role/targets/ParamConditionInputValue.tsx
+++ b/packages/app/src/components/views/Role/targets/ParamConditionInputValue.tsx
@@ -58,10 +58,20 @@ export const ParamConditionInputValue = ({ param, condition, disabled, onChange 
     }
     onChange({ ...condition, value: [value] })
   }
+
+  const tryAbiDecode = (param: ethers.utils.ParamType, value: string) => {
+    try {
+      return ethers.utils.defaultAbiCoder.decode([param], condition.value[0])
+    } catch (err) {
+      // when decoding fails return raw value instead of crashing
+      return value
+    }
+  }
+
   const humanReadableValue =
     dirty || condition.value[0] == null || condition.value[0] === ""
       ? condition.value[0]
-      : ethers.utils.defaultAbiCoder.decode([param], condition.value[0])
+      : tryAbiDecode(param, condition.value[0])
   return (
     <TextField
       error={!valid && dirty}

--- a/packages/subgraph/src/permissions.mapping.ts
+++ b/packages/subgraph/src/permissions.mapping.ts
@@ -137,8 +137,17 @@ export function handleScopeFunction(event: ScopeFunction): void {
   theFunction.wildcarded = false
   theFunction.save()
 
-  // create new parameter or override old one
+  if (theFunction.parameters != null) {
+    // remove old parameters if it exists
+    const parameters: string[] = theFunction.parameters!
+    for (let i = 0; i < parameters.length; i++) {
+      const parameterId = parameters[i]
+      store.remove("Parameter", parameterId)
+    }
+  }
+
   for (let i = 0; i < event.params.paramType.length; i++) {
+    // create new parameters
     if (event.params.isParamScoped[i]) {
       const paramType = PARAMETER_TYPE[event.params.paramType[i]]
       const paramComp = PARAMETER_COMPARISON[event.params.paramComp[i]]

--- a/packages/subgraph/src/permissions.mapping.ts
+++ b/packages/subgraph/src/permissions.mapping.ts
@@ -139,18 +139,20 @@ export function handleScopeFunction(event: ScopeFunction): void {
 
   // create new parameter or override old one
   for (let i = 0; i < event.params.paramType.length; i++) {
-    const paramType = PARAMETER_TYPE[event.params.paramType[i]]
-    const paramComp = PARAMETER_COMPARISON[event.params.paramComp[i]]
-    const compValue = event.params.compValue[i]
+    if (event.params.isParamScoped[i]) {
+      const paramType = PARAMETER_TYPE[event.params.paramType[i]]
+      const paramComp = PARAMETER_COMPARISON[event.params.paramComp[i]]
+      const compValue = event.params.compValue[i]
 
-    const parameterId = getParameterId(functionId, i)
-    const parameter = new Parameter(parameterId)
-    parameter.owningFunction = functionId
-    parameter.index = i
-    parameter.type = paramType
-    parameter.comparison = paramComp
-    parameter.comparisonValue = [compValue]
-    parameter.save()
+      const parameterId = getParameterId(functionId, i)
+      const parameter = new Parameter(parameterId)
+      parameter.owningFunction = functionId
+      parameter.index = i
+      parameter.type = paramType
+      parameter.comparison = paramComp
+      parameter.comparisonValue = [compValue]
+      parameter.save()
+    }
   }
 }
 


### PR DESCRIPTION
- Subgraph: Stop creating empty parameter scopes when there should be none.

- Subgraph: Remove old parameters when a function is re-scoped.

- App: Makes sure that the app does not crash if Ethers are unable to decode some parameter value.