### PR TITLE
app: generally allow entering custom ABI

### DIFF
--- a/packages/app/src/components/views/Role/targets/ParamConditionInput.tsx
+++ b/packages/app/src/components/views/Role/targets/ParamConditionInput.tsx
@@ -54,11 +54,19 @@ interface ParamConditionInputProps {
   param: ethers.utils.ParamType
   condition?: ParamCondition
   disabled?: boolean
+  onDecodingError(err: Error): void
 
   onChange(value?: ParamCondition): void
 }
 
-export const ParamConditionInput = ({ index, param, condition, disabled, onChange }: ParamConditionInputProps) => {
+export const ParamConditionInput = ({
+  index,
+  param,
+  condition,
+  disabled,
+  onChange,
+  onDecodingError,
+}: ParamConditionInputProps) => {
   const classes = useStyles()
   const nativeType = getNativeType(param)
   const type = getConditionType(nativeType)
@@ -139,7 +147,13 @@ export const ParamConditionInput = ({ index, param, condition, disabled, onChang
   return (
     <>
       {select}
-      <ParamConditionInputValue param={param} condition={condition} disabled={disabled} onChange={onChange} />
+      <ParamConditionInputValue
+        onDecodingError={onDecodingError}
+        param={param}
+        condition={condition}
+        disabled={disabled}
+        onChange={onChange}
+      />
       {removeButton}
     </>
   )

--- a/packages/app/src/components/views/Role/targets/ParamConditionInputValue.tsx
+++ b/packages/app/src/components/views/Role/targets/ParamConditionInputValue.tsx
@@ -9,6 +9,7 @@ interface ParamConditionInputValueProps {
   param: ethers.utils.ParamType
   condition: ParamCondition
   disabled?: boolean
+  onDecodingError(err: Error): void
 
   onChange(condition: ParamCondition): void
 }
@@ -43,7 +44,13 @@ function getPlaceholderForType(param: ethers.utils.ParamType) {
   return PlaceholderPerType[nativeType]
 }
 
-export const ParamConditionInputValue = ({ param, condition, disabled, onChange }: ParamConditionInputValueProps) => {
+export const ParamConditionInputValue = ({
+  param,
+  condition,
+  disabled,
+  onChange,
+  onDecodingError,
+}: ParamConditionInputValueProps) => {
   const classes = useStyles()
   const [valid, setValid] = useState<boolean>(false)
   const [dirty, setDirty] = useState(false)
@@ -63,6 +70,7 @@ export const ParamConditionInputValue = ({ param, condition, disabled, onChange 
     try {
       return ethers.utils.defaultAbiCoder.decode([param], condition.value[0])
     } catch (err) {
+      onDecodingError(err as Error)
       // when decoding fails return raw value instead of crashing
       return value
     }

--- a/packages/app/src/components/views/Role/targets/TargetConfiguration.tsx
+++ b/packages/app/src/components/views/Role/targets/TargetConfiguration.tsx
@@ -5,9 +5,8 @@ import { useAbi } from "../../../../hooks/useAbi"
 import { TargetFunctionList } from "./TargetFunctionList"
 import { FunctionFragment, Interface } from "@ethersproject/abi"
 import { RoleContext } from "../RoleContext"
-import { ZodiacPaper } from "zodiac-ui-components"
 import { Checkbox } from "../../../commons/input/Checkbox"
-import { getKeyFromFunction, isWriteFunction } from "../../../../utils/conditions"
+import { getKeyFromFunction, getWriteFunctions } from "../../../../utils/conditions"
 import classNames from "classnames"
 import { ExecutionOptions } from "./ExecutionOptions"
 
@@ -20,16 +19,7 @@ const useStyles = makeStyles((theme) => ({
       fontSize: 16,
     },
   },
-  root: {
-    padding: theme.spacing(2),
-    paddingRight: `calc(${theme.spacing(2)}px - 6px)`,
-    maxHeight: "calc(100vh - 275px)",
-    overflowY: "auto",
-    scrollbarGutter: "stable",
-    "&::-webkit-scrollbar": {
-      width: "6px",
-    },
-  },
+
   functionWrapper: {
     backgroundColor: "rgba(217, 212, 173, 0.1)",
     border: "1px solid rgba(217, 212, 173, 0.3)",
@@ -75,18 +65,6 @@ const useStyles = makeStyles((theme) => ({
     fontFamily: "Roboto Mono",
     fontSize: 12,
   },
-  disabledArea: {
-    opacity: 0.5,
-    "&::after": {
-      content: "''",
-      position: "absolute",
-      top: 0,
-      left: 0,
-      width: "100%",
-      height: "100%",
-      backgroundColor: "rgba(0,0,0,0.12)",
-    },
-  },
 }))
 
 type TargetConfigurationProps = {
@@ -119,8 +97,7 @@ export const TargetConfiguration = ({ target }: TargetConfigurationProps) => {
   const [isWildcarded, setIsWildcarded] = useState(target.type === ConditionType.WILDCARDED)
 
   useEffect(() => {
-    const funcs = !abi ? [] : Object.values(new Interface(abi).functions).filter(isWriteFunction)
-    setFunctions(funcs)
+    setFunctions(getWriteFunctions(abi))
     setRefresh(true)
   }, [abi])
 
@@ -196,17 +173,13 @@ export const TargetConfiguration = ({ target }: TargetConfigurationProps) => {
         </Box>
       ) : null}
       <Box className={classNames(classes.container)}>
-        <ZodiacPaper
-          borderStyle="single"
-          className={classNames(classes.root, { [classes.disabledArea]: isWildcarded })}
-        >
-          <TargetFunctionList
-            items={functions}
-            conditions={target.conditions}
-            onChange={handleFuncParamsChange}
-            onSubmit={(customABI) => setAbi(customABI)}
-          />
-        </ZodiacPaper>
+        <TargetFunctionList
+          items={functions}
+          conditions={target.conditions}
+          onChange={handleFuncParamsChange}
+          onSubmit={(customABI) => setAbi(customABI)}
+          wildcarded={isWildcarded}
+        />
       </Box>
     </Box>
   )

--- a/packages/app/src/components/views/Role/targets/TargetConfiguration.tsx
+++ b/packages/app/src/components/views/Role/targets/TargetConfiguration.tsx
@@ -88,7 +88,7 @@ function getInitialTargetConditions(functions: FunctionFragment[]): TargetCondit
 
 export const TargetConfiguration = ({ target }: TargetConfigurationProps) => {
   const classes = useStyles()
-  const { abi, setAbi } = useAbi(target.address)
+  const { abi, setAbi, fetchAbi, loading: abiLoading } = useAbi(target.address)
   const { setTargetConditions, setTargetClearance, setTargetExecutionOption, state } = useContext(RoleContext)
 
   console.log("update events", state.getTargetUpdate(target.id))
@@ -177,8 +177,10 @@ export const TargetConfiguration = ({ target }: TargetConfigurationProps) => {
           items={functions}
           conditions={target.conditions}
           onChange={handleFuncParamsChange}
-          onSubmit={(customABI) => setAbi(customABI)}
+          abiLoading={abiLoading}
+          onSubmit={(customABI) => (customABI.length ? setAbi(customABI) : fetchAbi())}
           wildcarded={isWildcarded}
+          key={target.id} // force discarding custom entered ABI state when switching between targets
         />
       </Box>
     </Box>

--- a/packages/app/src/components/views/Role/targets/TargetFunctionList.tsx
+++ b/packages/app/src/components/views/Role/targets/TargetFunctionList.tsx
@@ -1,6 +1,6 @@
 import { FunctionFragment } from "@ethersproject/abi"
 import { TargetFunction } from "./TargetFunction"
-import { FunctionCondition, TargetConditions } from "../../../../typings/role"
+import { ConditionType, ExecutionOption, FunctionCondition, TargetConditions } from "../../../../typings/role"
 import { getKeyFromFunction } from "../../../../utils/conditions"
 import { Box, Button, Grid, makeStyles, Typography, CircularProgress } from "@material-ui/core"
 import { ZodiacPaper, ZodiacTextField } from "zodiac-ui-components"
@@ -173,12 +173,12 @@ export const TargetFunctionList = ({
           {/* render functions that are in the ABI */}
           {items.map((func) => {
             const sighash = getKeyFromFunction(func)
-            if (!conditions[sighash]) return null
+            const funcConditions = conditions[sighash] || { ...INITIAL_CONDITION, sighash }
             return (
               <TargetFunction
                 key={sighash}
                 func={func}
-                functionConditions={conditions[sighash]}
+                functionConditions={funcConditions}
                 onChange={handleFunctionChange(sighash)}
               />
             )
@@ -200,4 +200,10 @@ export const TargetFunctionList = ({
       </Box>
     </>
   )
+}
+
+const INITIAL_CONDITION = {
+  type: ConditionType.BLOCKED,
+  executionOption: ExecutionOption.NONE,
+  params: [],
 }

--- a/packages/app/src/components/views/Role/targets/TargetFunctionList.tsx
+++ b/packages/app/src/components/views/Role/targets/TargetFunctionList.tsx
@@ -2,49 +2,86 @@ import { FunctionFragment } from "@ethersproject/abi"
 import { TargetFunction } from "./TargetFunction"
 import { FunctionCondition, TargetConditions } from "../../../../typings/role"
 import { getKeyFromFunction } from "../../../../utils/conditions"
-import { Button, Grid, Typography } from "@material-ui/core"
-import { ZodiacTextField } from "zodiac-ui-components"
+import { Box, Button, Grid, makeStyles, Typography } from "@material-ui/core"
+import { ZodiacPaper, ZodiacTextField } from "zodiac-ui-components"
 import { useState } from "react"
 import { JsonFragment } from "@ethersproject/abi"
+import classNames from "classnames"
+import { KeyboardArrowDownSharp, Check, EditOutlined, WarningOutlined } from "@material-ui/icons"
 
 interface TargetFunctionListProps {
   items: FunctionFragment[]
   conditions: TargetConditions
   onChange(conditions: TargetConditions): void
   onSubmit?: (customABI: JsonFragment[]) => void
+  wildcarded: boolean
 }
 
-export const TargetFunctionList = ({ items, conditions, onChange, onSubmit }: TargetFunctionListProps) => {
-  const [customABI, setCustomABI] = useState<JsonFragment[] | undefined>(undefined)
+const useStyles = makeStyles((theme) => ({
+  root: {
+    padding: theme.spacing(2),
+    paddingRight: `calc(${theme.spacing(2)}px - 6px)`,
+    maxHeight: "calc(100vh - 275px)",
+    overflowY: "auto",
+    scrollbarGutter: "stable",
+    "&::-webkit-scrollbar": {
+      width: "6px",
+    },
+  },
+  disabledArea: {
+    opacity: 0.5,
+    "&::after": {
+      content: "''",
+      position: "absolute",
+      top: 0,
+      left: 0,
+      width: "100%",
+      height: "100%",
+      backgroundColor: "rgba(0,0,0,0.12)",
+    },
+  },
+
+  title: {
+    display: "flex",
+    alignItems: "center",
+    minHeight: 32,
+  },
+  triggerTitle: {
+    display: "flex",
+    alignItems: "center",
+    cursor: "pointer",
+    minHeight: 32,
+  },
+  icon: {
+    height: 32,
+    fill: "#B2B5B2",
+    transition: "transform 0.25s ease-in-out",
+    width: 32,
+  },
+  rotate: {
+    transform: "rotate(180deg)",
+  },
+}))
+
+export const TargetFunctionList = ({ items, conditions, onChange, onSubmit, wildcarded }: TargetFunctionListProps) => {
+  const classes = useStyles()
+
+  const [customABI, setCustomABI] = useState<string>("")
+  const [usingCustomABI, setUsingCustomABI] = useState(false)
+  const [customABIExpanded, setCustomABIExpanded] = useState(false)
+
   const handleCustomABI = () => {
     if (onSubmit && (customABI || customABI !== "")) {
-      onSubmit(customABI as JsonFragment[])
+      try {
+        let json = JSON.parse(customABI) as JsonFragment[]
+        if (json.length > 0) {
+          onSubmit(json)
+          setUsingCustomABI(true)
+        }
+      } catch (err) {
+        console.error("invalid custom ABI", err)
+      }
     }
-  }
-  if (!items.length) {
-    return (
-      <Grid container direction="column" spacing={2}>
-        <Grid item>
-          <Typography>Unable to fetch ABI for this address</Typography>{" "}
-        </Grid>
-        <Grid item>
-          <ZodiacTextField
-            InputProps={{ style: { padding: 10 } }}
-            onChange={(evt: any) => setCustomABI(evt.target.value)}
-            label="Custom ABI"
-            value={customABI}
-            placeholder="Enter custom ABI here."
-            minRows={5}
-            multiline
-          />
-        </Grid>
-        <Grid item>
-          <Button color="secondary" variant="contained" onClick={handleCustomABI} disabled={!customABI}>
-            Submit Custom ABI
-          </Button>
-        </Grid>
-      </Grid>
-    )
   }
 
   const handleFunctionChange = (format: string) => (funcConditions: FunctionCondition) => {
@@ -58,34 +95,88 @@ export const TargetFunctionList = ({ items, conditions, onChange, onSubmit }: Ta
     (key) => !items.some((item) => getKeyFromFunction(item) === key),
   )
 
+  const expanded = customABIExpanded || items.length === 0
+
   return (
     <>
-      {/* render functions that are in the ABI */}
-      {items.map((func) => {
-        const sighash = getKeyFromFunction(func)
-        if (!conditions[sighash]) return null
-        return (
-          <TargetFunction
-            key={sighash}
-            func={func}
-            functionConditions={conditions[sighash]}
-            onChange={handleFunctionChange(sighash)}
-          />
-        )
-      })}
+      <ZodiacPaper borderStyle="single" className={classNames(classes.root, { [classes.disabledArea]: wildcarded })}>
+        <Grid container direction="column" spacing={2}>
+          <Grid item>
+            {!items.length ? (
+              <div className={classes.title}>
+                <WarningOutlined className={classes.icon} style={{ marginRight: 8 }} />
+                <Typography>Unable to fetch ABI for this address</Typography>
+              </div>
+            ) : (
+              <div className={classes.triggerTitle} onClick={() => setCustomABIExpanded(!expanded)}>
+                {usingCustomABI ? (
+                  <EditOutlined className={classes.icon} style={{ marginRight: 8 }} />
+                ) : (
+                  <Check className={classes.icon} style={{ marginRight: 8 }} />
+                )}
+                <Typography>{usingCustomABI ? "Using custom ABI" : "Contract ABI detected"}</Typography>
+                <Box sx={{ flexGrow: 1 }} />
+                {!expanded && (
+                  <Typography variant="body2" style={{ marginRight: 8 }}>
+                    click to enter custom ABI
+                  </Typography>
+                )}
+                <KeyboardArrowDownSharp className={classNames(classes.icon, { [classes.rotate]: expanded })} />
+              </div>
+            )}
+          </Grid>
+          {expanded && (
+            <>
+              <Grid item>
+                <ZodiacTextField
+                  InputProps={{ style: { padding: 10 } }}
+                  onChange={(evt) => setCustomABI(evt.target.value)}
+                  label="Custom ABI"
+                  value={customABI}
+                  placeholder="Enter custom ABI here."
+                  minRows={5}
+                  multiline
+                />
+              </Grid>
+              <Grid item>
+                <Button color="secondary" variant="contained" onClick={handleCustomABI} disabled={!customABI}>
+                  Submit Custom ABI
+                </Button>
+              </Grid>
+            </>
+          )}
+        </Grid>
+      </ZodiacPaper>
+      <Box mt={3}>
+        <ZodiacPaper borderStyle="single" className={classNames(classes.root, { [classes.disabledArea]: wildcarded })}>
+          {/* render functions that are in the ABI */}
+          {items.map((func) => {
+            const sighash = getKeyFromFunction(func)
+            if (!conditions[sighash]) return null
+            return (
+              <TargetFunction
+                key={sighash}
+                func={func}
+                functionConditions={conditions[sighash]}
+                onChange={handleFunctionChange(sighash)}
+              />
+            )
+          })}
 
-      {/* render functions that are not in the ABI */}
-      {sighashesNotInAbi.map((sighash) => {
-        const funcConditions = conditions[sighash]
-        return (
-          <TargetFunction
-            key={sighash}
-            func={sighash}
-            functionConditions={funcConditions}
-            onChange={handleFunctionChange(sighash)}
-          />
-        )
-      })}
+          {/* render functions that are not in the ABI */}
+          {sighashesNotInAbi.map((sighash) => {
+            const funcConditions = conditions[sighash]
+            return (
+              <TargetFunction
+                key={sighash}
+                func={sighash}
+                functionConditions={funcConditions}
+                onChange={handleFunctionChange(sighash)}
+              />
+            )
+          })}
+        </ZodiacPaper>
+      </Box>
     </>
   )
 }

--- a/packages/app/src/services/explorer.ts
+++ b/packages/app/src/services/explorer.ts
@@ -89,26 +89,17 @@ const looksLikeAProxy = (abi: JsonFragment[]) => {
   const signatures = Object.keys(iface.functions)
   return (
     signatures.length === 0 ||
-    (signatures.length === 1 && signatures[0] === "implementation()") ||
-    looksLikeAComptroller(abi)
+    (signatures.length === 1 && looksLike(abi, ["implementation()"])) ||
+    looksLike(abi, ERC897) ||
+    looksLike(abi, COMPTROLLER)
   )
 }
 
-const looksLikeAComptroller = (abi: JsonFragment[]) => {
+const ERC897 = ["proxyType()", "implementation(address)"]
+const COMPTROLLER = ["pendingAdmin()", "comptrollerImplementation()", "pendingComptrollerImplementation()", "admin()"]
+
+const looksLike = (abi: JsonFragment[], expectedFunctions: string[]) => {
   const iface = new Interface(abi)
   const signatures = Object.keys(iface.functions)
-  console.log({ signatures })
-  const comptrollerFunctions = [
-    "pendingAdmin()",
-    "_setPendingAdmin(address)",
-    "comptrollerImplementation()",
-    "_acceptImplementation()",
-    "pendingComptrollerImplementation()",
-    "_setPendingImplementation(address)",
-    "_acceptAdmin()",
-    "admin()",
-  ]
-  return (
-    signatures.length === comptrollerFunctions.length && signatures.every((sig) => comptrollerFunctions.includes(sig))
-  )
+  return expectedFunctions.every((sig) => signatures.includes(sig))
 }

--- a/packages/app/src/services/explorer.ts
+++ b/packages/app/src/services/explorer.ts
@@ -89,14 +89,11 @@ const looksLikeAProxy = (abi: JsonFragment[]) => {
   const signatures = Object.keys(iface.functions)
   return (
     signatures.length === 0 ||
-    (signatures.length === 1 && looksLike(abi, ["implementation()"])) ||
-    looksLike(abi, ERC897) ||
-    looksLike(abi, COMPTROLLER)
+    signatures ||
+    looksLike(abi, ["implementation()"]) || // for EIP-897/EIP-1967/... proxies
+    looksLike(abi, ["comptrollerImplementation()"]) // for Compound Comptroller
   )
 }
-
-const ERC897 = ["proxyType()", "implementation(address)"]
-const COMPTROLLER = ["pendingAdmin()", "comptrollerImplementation()", "pendingComptrollerImplementation()", "admin()"]
 
 const looksLike = (abi: JsonFragment[], expectedFunctions: string[]) => {
   const iface = new Interface(abi)

--- a/packages/app/src/utils/conditions.ts
+++ b/packages/app/src/utils/conditions.ts
@@ -1,5 +1,5 @@
 import { ConditionType, FunctionCondition, ParamComparison, ParameterType, ParamNativeType } from "../typings/role"
-import { FunctionFragment, Interface } from "@ethersproject/abi"
+import { FunctionFragment, Interface, JsonFragment } from "@ethersproject/abi"
 import { ethers } from "ethers"
 
 export function getFunctionConditionType(paramConditions: FunctionCondition["params"]) {
@@ -55,6 +55,9 @@ export function isWriteFunction(method: FunctionFragment) {
   if (!method.stateMutability) return true
   return !["view", "pure"].includes(method.stateMutability)
 }
+
+export const getWriteFunctions = (abi: JsonFragment[] | undefined) =>
+  !abi ? [] : Object.values(new Interface(abi).functions).filter(isWriteFunction)
 
 export function formatParamValue(param: ethers.utils.ParamType, value: string) {
   if (getNativeType(param) === ParamNativeType.ARRAY) return JSON.parse(value)


### PR DESCRIPTION
So far the app only allowed entering custom ABI if fetching it failed. We now generally give the option to paste ABI so there's an escape hatch in case the fetched ABI wrong, e.g. due to undetected proxy contracts.

This PR also includes a fix for #173.

It also slightly improves the proxy detection implemented in #179 

Should not be merged before #184.