### PR TITLE
fix a bug in the checking for param mismatch

### DIFF
--- a/packages/app/src/components/views/Role/targets/TargetFunctionParams.tsx
+++ b/packages/app/src/components/views/Role/targets/TargetFunctionParams.tsx
@@ -56,8 +56,13 @@ export const TargetFunctionParams = ({ func, funcConditions, disabled, onChange 
   const indices = Array.from({ length: maxIndex + 1 }, (_, i) => i)
 
   const parameterMismatch = (func: FunctionFragment, funcConditions: FunctionCondition): boolean =>
-    func.inputs.length < funcConditions.params.reduce((acc, param) => (acc < param.index ? param.index : acc), 0)
-
+    func.inputs.length <= funcConditions.params.reduce((acc, param) => (acc < param.index ? param.index : acc), 0)
+  console.log({
+    parameterMismatch: typeof func === "string" || parameterMismatch(func, funcConditions),
+    func: typeof func === "string" ? func : func.name,
+    funcConditions,
+    decodingError,
+  })
   return typeof func === "string" || parameterMismatch(func, funcConditions) || decodingError ? (
     <>
       {indices.map((index) => {


### PR DESCRIPTION
the max index must smaller than the params length for it to match actually.

the problem manifested itself as reported by Karpatkey:

> The collect function of the Positions NFT contract (0xC36442b4a4522E871399CD717aBDD847Ab11FE88) is not showing the parameters correctly:
> ![image](https://user-images.githubusercontent.com/524089/219107515-b6cc5c5b-30b0-4a9f-a5ea-4f75ec7e248c.png)
> 