### PR TITLE
keep event field names consistent

### DIFF
--- a/packages/evm/contracts/PermissionBuilder.sol
+++ b/packages/evm/contracts/PermissionBuilder.sol
@@ -38,7 +38,7 @@ abstract contract PermissionBuilder is Core {
     event ScopeFunction(
         uint16 role,
         address targetAddress,
-        bytes4 functionSig,
+        bytes4 selector,
         ConditionFlat[] conditions,
         ExecutionOptions options
     );


### PR DESCRIPTION
It's now consistent with `AllowFunction` event