### PR TITLE
Fix `c.matches` integrity check

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "search.exclude": {
     "**/build": true

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zodiac-roles-sdk",
-  "version": "2.2.17",
+  "version": "2.2.18",
   "license": "LGPL-3.0+",
   "main": "build/cjs/sdk/src/index.js",
   "module": "build/esm/sdk/src/index.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zodiac-roles-sdk",
-  "version": "2.2.18",
+  "version": "2.2.19",
   "license": "LGPL-3.0+",
   "main": "build/cjs/sdk/src/index.js",
   "module": "build/esm/sdk/src/index.js",

--- a/packages/sdk/src/permissions/authoring/conditions/matches.ts
+++ b/packages/sdk/src/permissions/authoring/conditions/matches.ts
@@ -394,19 +394,12 @@ const checkScopedType = (condition: Condition): ParameterType => {
     const [first, ...rest] = condition.children
     const result = checkScopedType(first)
 
+    // assert that all following children have compatible types
     rest.forEach((child) => {
       const childType = checkScopedType(child)
       checkParameterTypeCompatibility(result, childType)
     })
 
-    // assert uniform children types
-    if (rest.some((child) => checkScopedType(child) !== result)) {
-      throw new Error(
-        `Invalid \`${
-          Operator[condition.operator]
-        }\` condition: mixed children types`
-      )
-    }
     return result
   }
 

--- a/packages/sdk/src/permissions/authoring/conditions/matches.ts
+++ b/packages/sdk/src/permissions/authoring/conditions/matches.ts
@@ -1,6 +1,7 @@
 import { BigNumber, BigNumberish } from "ethers"
 import { ParamType, isHexString, isBytes } from "ethers/lib/utils"
 
+import { checkParameterTypeCompatibility } from "../../../conditions/checkConditionIntegrity"
 import { Condition, Operator, ParameterType } from "../../../types"
 import { AbiType, FunctionPermission } from "../../types"
 import { coercePermission } from "../../utils"
@@ -392,6 +393,11 @@ const checkScopedType = (condition: Condition): ParameterType => {
 
     const [first, ...rest] = condition.children
     const result = checkScopedType(first)
+
+    rest.forEach((child) => {
+      const childType = checkScopedType(child)
+      checkParameterTypeCompatibility(result, childType)
+    })
 
     // assert uniform children types
     if (rest.some((child) => checkScopedType(child) !== result)) {


### PR DESCRIPTION
It was overly restrictive in not supporting children with `ParameterType.Bytes` to follow `ParameterType.AbiEncoded`. It now shares the logic with `checkConditionIntegrity`.